### PR TITLE
Fix async benchmark: Promise support, proxy unwrapping, and preset usage

### DIFF
--- a/.changeset/fix-async-promise-support.md
+++ b/.changeset/fix-async-promise-support.md
@@ -1,0 +1,9 @@
+---
+"nookjs": patch
+---
+
+Fix Promise support in async evaluation
+
+- Prevent auto-awaiting of Promise values returned from host functions, preserving Promise identity for `.then()` chaining
+- Allow `.catch` and `.finally` access on Promises (previously only `.then` was allowlisted)
+- Unwrap non-plain-object proxies for native method compatibility (e.g., `clearTimeout` with proxied `Timeout` objects)

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # Benchmark results
 benchmark-results.json
+benchmark-async-results.json
 
 # *.local.* files
 *.local.*

--- a/src/readonly-proxy.ts
+++ b/src/readonly-proxy.ts
@@ -74,7 +74,20 @@ export function unwrapForNative(value: unknown): unknown {
     return target;
   }
 
-  // For other proxy types, return the original proxy
+  // Unwrap non-plain-object proxies for native method compatibility.
+  // Host functions like clearTimeout need the original object (e.g., Timeout),
+  // not a proxy. Plain objects and arrays stay wrapped for security.
+  if (
+    typeof target === "object" &&
+    target !== null &&
+    !Array.isArray(target) &&
+    Object.getPrototypeOf(target) !== Object.prototype &&
+    Object.getPrototypeOf(target) !== null
+  ) {
+    return target;
+  }
+
+  // For plain objects, arrays, and other proxy types, return the original proxy
   return value;
 }
 

--- a/test/console.test.ts
+++ b/test/console.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 
 import { Interpreter } from "../src/interpreter";
-import { ES2024, ConsoleAPI } from "../src/presets";
+import { ES2024, ConsoleAPI, preset } from "../src/presets";
 
 describe("Console", () => {
   describe("API", () => {
     let interpreter: Interpreter;
 
     beforeEach(() => {
-      interpreter = new Interpreter({ ...ES2024, ...ConsoleAPI });
+      interpreter = new Interpreter(preset(ES2024, ConsoleAPI));
     });
 
     describe("console.log", () => {

--- a/test/timers.test.ts
+++ b/test/timers.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 
 import { Interpreter } from "../src/interpreter";
-import { ES2024, TimersAPI } from "../src/presets";
+import { ES2024, TimersAPI, preset } from "../src/presets";
 
 describe("Timers", () => {
   describe("API", () => {
     let interpreter: Interpreter;
 
     beforeEach(() => {
-      interpreter = new Interpreter({ ...ES2024, ...TimersAPI });
+      interpreter = new Interpreter(preset(ES2024, TimersAPI));
     });
 
     describe("setTimeout", () => {


### PR DESCRIPTION
## Summary

The async benchmark (`bun benchmark:async`) was completely broken — it crashed immediately and couldn't run a single case. This PR fixes the underlying interpreter bugs and cleans up preset usage across benchmarks and tests.

## Changes

### Promise auto-awaiting fix (`src/interpreter.ts`)

The core issue: in `evaluateNodeAsync`, JavaScript's `async`/`await` mechanics automatically resolve Promise values. So `Promise.resolve(1)` returned from a host function would be collapsed to `1` before the interpreter could chain `.then()` on it.

Fixed by wrapping Promise results in `RawValue` (an existing pattern already used for `NewExpression`) at all production sites in the async evaluation path, and unwrapping at all consumption sites:

- `evaluateCallExpressionAsync` — wrap host function and native function Promise returns
- `evaluateNodeAsync` Identifier case — wrap Promise variable lookups
- `evaluateArgumentsAsync`, `evaluateAwaitExpressionAsync`, `evaluateAssignmentExpressionAsync`, `evaluateReturnStatementAsync`, `evaluateMemberExpressionAsync`, `evaluateArrayExpressionAsync` — unwrap at consumption

### Prototype access allowlist (`src/interpreter.ts`)

`ensureNoPrototypeAccess` blocked `.catch` and `.finally` on Promises. Added them to the allowlist alongside `.then`.

### Proxy unwrapping for native methods (`src/readonly-proxy.ts`)

`clearTimeout` couldn't cancel proxied `Timeout` objects. Updated `unwrapForNative` to unwrap non-plain-object proxies (objects with non-`Object.prototype` prototypes like `Timeout`, `Date`, `RegExp`) while keeping plain objects and arrays wrapped for security.

### Benchmark fixes (`benchmarks/async.ts`)

- Use `ES2024` preset via `preset()` instead of bare `new Interpreter()` (which had no Error constructors)
- Add per-case error handling so the benchmark continues past failures
- Report skipped benchmarks in summary

### Preset usage cleanup (`test/console.test.ts`, `test/timers.test.ts`)

Replaced manual `{ ...ES2024, ...ConsoleAPI }` spreads with `preset(ES2024, ConsoleAPI)`.

## Results

- 3347/3347 tests pass
- 17/18 benchmark cases pass
- 1 benchmark skipped ("Concurrent Fetch Pattern") — pre-existing bug where `.map` with async callbacks fails because the interpreter's array `.map` uses synchronous `callCallback`
