### PR TITLE
Refactor member access to centralized blacklist handling

### DIFF
--- a/.changeset/soft-rabbits-approve.md
+++ b/.changeset/soft-rabbits-approve.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Refactor member access to centralize blacklist checks while preserving array/string method overrides.


### PR DESCRIPTION
**Summary**
- Centralize member access handling to enforce blacklist checks consistently.
- Preserve array/string overrides for sandbox-aware method behavior.
- Align computed access and host function protections with existing security expectations.

**Changes**
- Introduced shared member resolution helpers for string/symbol properties.
- Unified sync/async member access logic to use the same resolution path.
- Restored array computed access semantics (numeric indices only).
- Hardened host function access to block dangerous computed properties.

**Tests**
- `bun test test/arrays.test.ts test/security.test.ts`
- `bun test test/native-method-delegation.test.ts test/host-functions.test.ts`
- `bun test`

**Notes**
- This refactor keeps existing behavioral quirks (e.g., array callbacks visiting holes) by retaining explicit overrides while moving default behavior to a blacklist-first path.
