### PR TITLE
Top-level await is module-only; runModule uses per-run options

### DIFF
--- a/.changeset/soft-foxes-argue.md
+++ b/.changeset/soft-foxes-argue.md
@@ -1,0 +1,5 @@
+---
+"nookjs": minor
+---
+
+Restrict top-level await to module evaluation and run modules through the full per-run evaluation options (globals, limits, validator, signal).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ### Minor Changes
 
 - 35fe723: Add ES module support with import/export syntax
-
   - Support all import types: named, default, namespace, side-effect only
   - Support all export types: named declarations, default, re-exports, `export * as namespace`
   - Pluggable `ModuleResolver` interface for loading modules from any source
@@ -17,7 +16,6 @@
 
 - a76f9e2: Add simplified `createSandbox` and `run` APIs with env presets, add-on APIs, and structured limits.
 - 72e527a: Add TypedArray support for mutation and static methods
-
   - Enable TypedArray element mutation via numeric indices (e.g., `arr[0] = 10`)
   - Allow inherited static methods on host functions (e.g., `Uint8Array.from()`, `Uint8Array.of()`)
   - Unwrap TypedArray/ArrayBuffer proxies when passed to native host methods like `TextDecoder.decode()`
@@ -26,7 +24,6 @@
 ### Patch Changes
 
 - b6850f7: Fix Promise support in async evaluation
-
   - Prevent auto-awaiting of Promise values returned from host functions, preserving Promise identity for `.then()` chaining
   - Allow `.catch` and `.finally` access on Promises (previously only `.then` was allowlisted)
   - Unwrap non-plain-object proxies for native method compatibility (e.g., `clearTimeout` with proxied `Timeout` objects)

--- a/docs/ASYNC_AWAIT.md
+++ b/docs/ASYNC_AWAIT.md
@@ -12,5 +12,6 @@
 
 ## Gotchas
 
-- No top-level `await` in sync evaluation.
+- Top-level `await` is only supported in module evaluation (`runModule` / `evaluateModuleAsync`).
+- In non-module evaluation, `await` is only valid inside async functions.
 - Calling async host functions in sync mode throws.

--- a/docs/SIMPLIFIED_API.md
+++ b/docs/SIMPLIFIED_API.md
@@ -130,6 +130,8 @@ const exports = await sandbox.runModule(
 );
 ```
 
+`runModule` accepts the same per-run options as `run` (globals, features, limits, validator, signal) plus the required `path`.
+
 ### `result: "full"`
 
 Return stats and resource usage alongside the result.

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1728,6 +1728,9 @@ class Parser {
       (this.currentType === TOKEN.Keyword || this.currentType === TOKEN.Identifier) &&
       this.currentValue === "await";
     if (isAwait) {
+      if (!this.inAsync && !this.allowTopLevelAwait) {
+        throw new ParseError("Unexpected token: await");
+      }
       this.next();
     }
 
@@ -4177,6 +4180,11 @@ class Parser {
 
 export function parseModule(input: string, _options: ParseOptions = {}): ESTree.Program {
   const parser = new Parser(input, true);
+  return parser.parseProgram();
+}
+
+export function parseScript(input: string, _options: ParseOptions = {}): ESTree.Program {
+  const parser = new Parser(input, false);
   return parser.parseProgram();
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { Interpreter, InterpreterError } from "./interpreter";
 export type {
   InterpreterOptions,
   EvaluateOptions,
+  ModuleEvaluateOptions,
   ParseOptions,
   LanguageFeature,
   FeatureControl,

--- a/test/ast.test.ts
+++ b/test/ast.test.ts
@@ -601,11 +601,14 @@ describe("AST", () => {
         const interpreter = new Interpreter({ globals: { delay } });
 
         const ast = interpreter.parse(`
-        let count = 0;
-        while (true) {
-          count = count + 1;
-          await delay(1);
+        async function run() {
+          let count = 0;
+          while (true) {
+            count = count + 1;
+            await delay(1);
+          }
         }
+        run()
       `);
 
         setTimeout(() => controller.abort(), 25);

--- a/test/execution-control.test.ts
+++ b/test/execution-control.test.ts
@@ -59,10 +59,13 @@ describe("Execution Control", () => {
           return expect(
             interpreter.evaluateAsync(
               `
-          async function recurse(n) {
-            return await recurse(n + 1);
+          async function run() {
+            async function recurse(n) {
+              return await recurse(n + 1);
+            }
+            return await recurse(0);
           }
-          await recurse(0);
+          run()
         `,
               { maxCallStackDepth: 50 },
             ),
@@ -234,9 +237,12 @@ describe("Execution Control", () => {
           return expect(
             interpreter.evaluateAsync(
               `
-          while (true) {
-            await Promise.resolve();
+          async function run() {
+            while (true) {
+              await Promise.resolve();
+            }
           }
+          run()
         `,
               { maxLoopIterations: 100 },
             ),
@@ -322,11 +328,14 @@ describe("Execution Control", () => {
           return expect(
             interpreter.evaluateAsync(
               `
-          const objects = [];
-          for (let i = 0; i < 1000; i++) {
-            objects.push({ a: 1, b: 2, c: 3 });
-            await Promise.resolve();
+          async function run() {
+            const objects = [];
+            for (let i = 0; i < 1000; i++) {
+              objects.push({ a: 1, b: 2, c: 3 });
+              await Promise.resolve();
+            }
           }
+          run()
         `,
               { maxMemory: 1000, maxLoopIterations: 100000 },
             ),
@@ -449,11 +458,14 @@ describe("Execution Control", () => {
         return expect(
           interpreter.evaluateAsync(
             `
-        var count = 0;
-        while (true) {
-          count = count + 1;
-          await delay(1);
+        async function run() {
+          var count = 0;
+          while (true) {
+            count = count + 1;
+            await delay(1);
+          }
         }
+        run()
       `,
             { signal: controller.signal },
           ),

--- a/test/operators.test.ts
+++ b/test/operators.test.ts
@@ -1899,10 +1899,13 @@ describe("Operators", () => {
         test("+= on object property in async context", async () => {
           const interpreter = new Interpreter({ globals: { Promise } });
           const result = await interpreter.evaluateAsync(`
-            let obj = { value: 10 };
-            await Promise.resolve();
-            obj.value += 5;
-            obj.value;
+            async function run() {
+              let obj = { value: 10 };
+              await Promise.resolve();
+              obj.value += 5;
+              return obj.value;
+            }
+            run()
           `);
           expect(result).toBe(15);
         });

--- a/test/presets.test.ts
+++ b/test/presets.test.ts
@@ -236,7 +236,10 @@ describe("Presets", () => {
 
           const start = Date.now();
           await interpreter.evaluateAsync(`
-            await new Promise(resolve => setTimeout(resolve, 50));
+            async function run() {
+              await new Promise(resolve => setTimeout(resolve, 50));
+            }
+            run()
           `);
           const elapsed = Date.now() - start;
 

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -1078,9 +1078,14 @@ describe("Security", () => {
           security: { hideHostErrorMessages: true },
         });
 
-        return expect(interpreter.evaluateAsync("await asyncThrow()")).rejects.toThrow(
-          "[error details hidden]",
-        );
+        return expect(
+          interpreter.evaluateAsync(`
+          async function run() {
+            return await asyncThrow();
+          }
+          run()
+        `),
+        ).rejects.toThrow("[error details hidden]");
       });
     });
 

--- a/test/timers.test.ts
+++ b/test/timers.test.ts
@@ -68,11 +68,14 @@ describe("Timers", () => {
 
       it("should clear timeout before execution", async () => {
         const result = await interpreter.evaluateAsync(`
-          let executed = false;
-          const timeoutId = setTimeout(() => { executed = true; }, 10);
-          clearTimeout(timeoutId);
-          await new Promise(resolve => setTimeout(resolve, 20));
-          executed
+          async function run() {
+            let executed = false;
+            const timeoutId = setTimeout(() => { executed = true; }, 10);
+            clearTimeout(timeoutId);
+            await new Promise(resolve => setTimeout(resolve, 20));
+            return executed;
+          }
+          run()
         `);
         expect(result).toBe(false);
       });

--- a/test/variables.test.ts
+++ b/test/variables.test.ts
@@ -1633,7 +1633,10 @@ describe("Variables", () => {
           const interpreter = new Interpreter();
           const result = await interpreter.evaluateAsync(`
             async function foo({ x, y }) { return x + y; }
-            await foo({ x: 10, y: 5 });
+            async function run() {
+              return await foo({ x: 10, y: 5 });
+            }
+            run();
           `);
           expect(result).toBe(15);
         });

--- a/www/src/pages/playground.tsx
+++ b/www/src/pages/playground.tsx
@@ -61,6 +61,7 @@ const result = await sandbox.run(code);`,
       const result = await sandbox.run(code);
 
       if (result) {
+        // eslint-disable-next-line
         setOutput(String(result));
       } else {
         setOutput(null);


### PR DESCRIPTION
## Summary

1. Run modules through the full evaluation pipeline so per-run globals, limits, validators, and signals apply consistently.
2. Restrict top-level `await` to module context and reject it in scripts, including `for await...of`.
3. Enable the module system when `modules: {}` is provided and align docs/tests with the new behavior.

## Key Changes

1. Added `parseScript` and script/module-specific validation, including a top-level `await` guard in script parsing.
2. Updated `runModule` to accept full per-run options and plumb them into module evaluation.
3. Refreshed tests to avoid top-level `await` in scripts and added coverage for `runModule` per-run globals/limits and TLA-in-modules.

## Testing

1. `bun typecheck`
2. `bun test`
