### PR TITLE
Improve Simplified API Safety, Typing, and Onboarding

### DIFF
--- a/.changeset/clean-oranges-help.md
+++ b/.changeset/clean-oranges-help.md
@@ -1,0 +1,12 @@
+---
+"nookjs": minor
+---
+
+Improve the simplified sandbox API and onboarding experience:
+
+- add safe default per-run limits for `createSandbox()` (`callDepth`, `loops`, `memoryBytes`)
+- add first-class `timeoutMs` support for async `run()` and `runModule()` (sandbox default + per-call override)
+- add typed generics for `run`, `runSync`, and `runModule` return values
+- add a `test` script to `package.json`
+- migrate examples to the simplified API and move internal `Interpreter` usage to `examples/internal`
+- document timeout support, safe defaults, typed run helpers, and example organization

--- a/README.md
+++ b/README.md
@@ -114,12 +114,14 @@ await sandbox.run("Math.PI"); // Error: Math is not defined
 
 ### Security Best Practices
 
-1. **Always use timeouts** to prevent infinite loops:
+1. **Use built-in timeouts** for async/untrusted workloads:
 
 ```typescript
-const sandbox = createSandbox({ env: "es2022" });
-const timeout = new Promise((_, reject) => setTimeout(() => reject(new Error("Timeout")), 5000));
-const result = await Promise.race([sandbox.run(untrustedCode), timeout]);
+const sandbox = createSandbox({ env: "es2022", timeoutMs: 5000 });
+const result = await sandbox.run(untrustedCode);
+
+// Optional per-run override
+await sandbox.run(untrustedCode, { timeoutMs: 1000 });
 ```
 
 2. **Clone sensitive data** before passing as globals:
@@ -414,6 +416,7 @@ Supported (stripped):
 - [Module System](docs/MODULES.md) - ES module support with import/export syntax
 - [Language Features](docs/README.md) - Detailed documentation for each supported feature
 - [Builtin Globals](docs/BUILTIN_GLOBALS.md) - Available built-in globals
+- [Examples](examples/README.md) - Simplified API examples and advanced/internal examples
 
 ## API Reference
 
@@ -447,8 +450,10 @@ const ast = parse("1 + 2");
 - `env`: Language preset (`"minimal"`, `"es2022"`, `"esnext"`, `"browser"`, `"node"`, `"wintercg"`)
 - `apis`: Add-on globals (`"fetch"`, `"console"`, `"timers"`, `"crypto"`, `"text"`, `"streams"`, etc.)
 - `globals`: Host-provided values
-- `limits.perRun`: Per-evaluation guards (`loops`, `callDepth`, `memoryBytes`)
+- `limits.perRun`: Per-evaluation guards (`loops`, `callDepth`, `memoryBytes`) with safe defaults
+  of `{ loops: 100_000, callDepth: 250, memoryBytes: 16MB }`
 - `limits.total`: Cumulative resource limits (requires integrated tracking)
+- `timeoutMs`: First-class async timeout (sandbox-level default or per-run override)
 - `policy.errors`: `"safe"` | `"sanitize"` | `"full"`
 - `modules`: `{ files, ast, externals }` for easy module resolution
 

--- a/docs/INTERNAL_CLASSES.md
+++ b/docs/INTERNAL_CLASSES.md
@@ -5,6 +5,7 @@ fine-grained control, you can use the internal classes exposed from the package.
 
 > These are advanced APIs. Prefer `createSandbox` unless you need direct access to the
 > interpreter or module internals.
+> See also: [`examples/internal/interpreter.ts`](../examples/internal/interpreter.ts).
 
 ## Interpreter
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -237,7 +237,13 @@ By default, host error messages are hidden from the sandbox. If you need to see 
 ## Execution Limits
 
 The sandbox provides execution limits to protect against denial-of-service attacks from untrusted
-code. These limits are configured per run:
+code. Safe per-run defaults are enabled automatically:
+
+- `callDepth: 250`
+- `loops: 100_000`
+- `memoryBytes: 16 * 1024 * 1024`
+
+You can tighten or relax these limits per run:
 
 ```typescript
 const sandbox = createSandbox({ env: "es2022" });
@@ -332,16 +338,13 @@ sandbox.runSync(
 
 ### Combined with Timeout
 
-For comprehensive protection, combine execution limits with a host-side timeout:
+For async evaluations, use first-class `timeoutMs`:
 
 ```typescript
-const timeout = new Promise((_, reject) => setTimeout(() => reject(new Error("Timeout")), 5000));
-await Promise.race([
-  sandbox.run(code, {
-    limits: { callDepth: 100, loops: 100000, memoryBytes: 10 * 1024 * 1024 },
-  }),
-  timeout,
-]);
+await sandbox.run(code, {
+  timeoutMs: 5000,
+  limits: { callDepth: 100, loops: 100000, memoryBytes: 10 * 1024 * 1024 },
+});
 ```
 
 ### Execution Limits and AbortSignal

--- a/docs/SIMPLIFIED_API.md
+++ b/docs/SIMPLIFIED_API.md
@@ -20,6 +20,7 @@ import { createSandbox } from "nookjs";
 const sandbox = createSandbox({
   env: "es2022",
   apis: ["console"],
+  timeoutMs: 5000,
   globals: {
     PI: 3.14159,
     double: (x: number) => x * 2,
@@ -89,6 +90,12 @@ const sandbox = createSandbox({
 
 Guard execution per run and over time.
 
+Safe per-run defaults are enabled automatically:
+
+- `loops: 100_000`
+- `callDepth: 250`
+- `memoryBytes: 16 * 1024 * 1024`
+
 ```typescript
 const sandbox = createSandbox({
   env: "es2022",
@@ -97,6 +104,19 @@ const sandbox = createSandbox({
     total: { evaluations: 100, memoryBytes: 50_000_000 },
   },
 });
+```
+
+### `timeoutMs`
+
+Set async execution timeouts without wrapping `run()` in `Promise.race`.
+
+```typescript
+const sandbox = createSandbox({
+  env: "es2022",
+  timeoutMs: 5000, // default timeout for sandbox.run/runModule
+});
+
+await sandbox.run(untrustedCode, { timeoutMs: 1000 }); // per-call override
 ```
 
 ### `policy`
@@ -130,7 +150,7 @@ const exports = await sandbox.runModule(
 );
 ```
 
-`runModule` accepts the same per-run options as `run` (globals, features, limits, validator, signal) plus the required `path`.
+`runModule` accepts the same per-run options as `run` (globals, features, limits, timeoutMs, validator, signal) plus the required `path`.
 
 ### `result: "full"`
 
@@ -139,6 +159,17 @@ Return stats and resource usage alongside the result.
 ```typescript
 const out = await sandbox.run("1 + 2", { result: "full" });
 console.log(out.value, out.stats);
+```
+
+### Typed result helpers
+
+Use generics when you want typed return values from `run` and `runModule`:
+
+```typescript
+const value = await sandbox.run<number>("40 + 2");
+const moduleExports = await sandbox.runModule<{ result: number }>("export const result = 40 + 2;", {
+  path: "main.js",
+});
 ```
 
 ## Advanced API

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,25 @@
+# Examples
+
+These examples are organized by API level.
+
+## Simplified API (Recommended)
+
+These files use `createSandbox()`, `run()`, and `parse()`:
+
+- `arrow-functions.ts`
+- `async.ts`
+- `environment-presets.ts`
+- `error-handling.ts`
+- `global-objects.ts`
+- `globals.ts`
+- `host-functions.ts`
+- `loops.ts`
+- `objects.ts`
+- `recursion.ts`
+- `validators.ts`
+
+## Advanced / Internal APIs
+
+Internal APIs are for lower-level control and are intentionally separated:
+
+- `internal/interpreter.ts`

--- a/examples/arrow-functions.ts
+++ b/examples/arrow-functions.ts
@@ -1,64 +1,23 @@
-import { Interpreter, ts } from "../src/index";
+import { createSandbox, ts } from "../src/index";
 
-const arrowExpr = new Interpreter();
-const arrowExprCode = ts`
-  let double = x => x * 2;
-  let add = (a, b) => a + b;
+const sandbox = createSandbox({ env: "es2022" });
+
+const expression = await sandbox.run<number>(ts`
+  const double = (x) => x * 2;
+  const add = (a, b) => a + b;
   double(5) + add(3, 7)
-`;
-arrowExpr.evaluate(arrowExprCode);
+`);
 
-const arrowBlock = new Interpreter();
-const arrowBlockCode = ts`
-  let factorial = n => {
-    let result = 1;
-    for (let i = 1; i <= n; i++) {
-      result = result * i;
-    }
-    return result;
-  };
-  factorial(6)
-`;
-arrowBlock.evaluate(arrowBlockCode);
-
-const arrowHigherOrder = new Interpreter();
-const arrowHigherOrderCode = ts`
-  function map(arr, f) {
-    let result = [];
-    for (let i = 0; i < arr.length; i++) {
-      result[i] = f(arr[i]);
-    }
-    return result;
-  }
-  let nums = [1, 2, 3, 4, 5];
-  let squared = map(nums, x => x * x);
-  squared[3]
-`;
-arrowHigherOrder.evaluate(arrowHigherOrderCode);
-
-const arrowClosure = new Interpreter();
-const arrowClosureCode = ts`
-  let makeAdder = x => y => x + y;
-  let add10 = makeAdder(10);
+const closure = await sandbox.run<number>(ts`
+  const makeAdder = (x) => (y) => x + y;
+  const add10 = makeAdder(10);
   add10(5)
-`;
-arrowClosure.evaluate(arrowClosureCode);
+`);
 
-const arrowFilter = new Interpreter();
-const arrowFilterCode = ts`
-  function filter(arr, pred) {
-    let result = [];
-    let j = 0;
-    for (let i = 0; i < arr.length; i++) {
-      if (pred(arr[i])) {
-        result[j] = arr[i];
-        j = j + 1;
-      }
-    }
-    return result;
-  }
-  let nums = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-  let evens = filter(nums, n => n % 2 === 0);
-  evens.length
-`;
-arrowFilter.evaluate(arrowFilterCode);
+const higherOrder = await sandbox.run<number>(ts`
+  const nums = [1, 2, 3, 4, 5];
+  const squared = nums.map((x) => x * x);
+  squared[3]
+`);
+
+console.log({ expression, closure, higherOrder });

--- a/examples/async.ts
+++ b/examples/async.ts
@@ -1,149 +1,42 @@
-import { Interpreter, ts } from "../src/index";
+import { createSandbox, ts } from "../src/index";
 
-const asyncInterpreter = new Interpreter({
+const sandbox = createSandbox({
+  env: "es2022",
   globals: {
     fetchData: async (id: number) => {
-      return new Promise((resolve) => {
-        setTimeout(() => resolve(`Data for ID ${id}`), 10);
+      return new Promise<number>((resolve) => {
+        setTimeout(() => resolve(id * 2), 10);
       });
     },
     asyncDouble: async (x: number) => x * 2,
   },
 });
 
-await asyncInterpreter.evaluateAsync(ts`fetchData(42)`);
-await asyncInterpreter.evaluateAsync(ts`asyncDouble(5) + asyncDouble(10)`);
+const hostAsync = await sandbox.run<number>(ts`
+  async function run() {
+    const data = await fetchData(21);
+    return await asyncDouble(data);
+  }
+  run();
+`);
 
-const complexAsyncInterpreter = new Interpreter({
-  globals: {
-    asyncGetUser: async (id: number) => ({
-      id,
-      name: `User${id}`,
-      active: true,
-    }),
-    asyncCalculate: async (a: number, b: number) => {
-      return new Promise((resolve) => {
-        setTimeout(() => resolve(a * b + 10), 5);
-      });
-    },
-  },
-});
-
-await complexAsyncInterpreter.evaluateAsync(ts`
-    let user = asyncGetUser(123);
-    user.name
-  `);
-
-await complexAsyncInterpreter.evaluateAsync(ts`
-    asyncCalculate(5, asyncCalculate(2, 3))
-  `);
-
-const asyncLoopInterpreter = new Interpreter({
-  globals: {
-    asyncIncrement: async (x: number) => x + 1,
-  },
-});
-
-await asyncLoopInterpreter.evaluateAsync(ts`
-    let sum = 0;
-    for (let i = 0; i < 5; i++) {
-      sum = sum + asyncIncrement(i);
+const asyncLoop = await sandbox.run<number>(ts`
+  async function run() {
+    let total = 0;
+    for (let i = 0; i < 4; i++) {
+      total = total + (await asyncDouble(i));
     }
-    sum
-  `);
+    return total;
+  }
+  run();
+`);
 
-await asyncLoopInterpreter.evaluateAsync(ts`
-    let result;
-    if (asyncIncrement(5) > 5) {
-      result = "greater";
-    } else {
-      result = "not greater";
-    }
-    result
-  `);
+const asyncArrow = await sandbox.run<number>(ts`
+  const plusOne = async (x) => x + 1;
+  async function run() {
+    return await plusOne(41);
+  }
+  run();
+`);
 
-const mixedAsyncInterpreter = new Interpreter({
-  globals: {
-    syncAdd: (a: number, b: number) => a + b,
-    asyncMultiply: async (a: number, b: number) => a * b,
-  },
-});
-
-await mixedAsyncInterpreter.evaluateAsync(ts`
-    asyncMultiply(syncAdd(2, 3), syncAdd(4, 6))
-  `);
-
-const sandboxAsyncInterpreter = new Interpreter();
-
-await sandboxAsyncInterpreter.evaluateAsync(ts`
-    async function getData() {
-      return 42;
-    }
-    async function process() {
-      let data = await getData();
-      return data * 2;
-    }
-    process()
-  `);
-
-await sandboxAsyncInterpreter.evaluateAsync(ts`
-    async function fetchUser(id) {
-      return { id: id, name: "User" + id, active: true };
-    }
-    async function getUsername(id) {
-      let user = await fetchUser(id);
-      return user.name;
-    }
-    getUsername(123)
-  `);
-
-const mixedSandboxInterpreter = new Interpreter({
-  globals: {
-    asyncFetch: async (id: number) => `Data${id}`,
-  },
-});
-
-await mixedSandboxInterpreter.evaluateAsync(ts`
-    async function processData(id) {
-      let data = await asyncFetch(id);
-      return data + " processed";
-    }
-    processData(999)
-  `);
-
-await sandboxAsyncInterpreter.evaluateAsync(ts`
-    let asyncDouble = async (x) => x * 2;
-    let asyncProcess = async (x) => {
-      let doubled = await asyncDouble(x);
-      return doubled + 10;
-    };
-    asyncProcess(5)
-  `);
-
-await mixedSandboxInterpreter.evaluateAsync(ts`
-    async function increment(x) {
-      return x + 1;
-    }
-    async function sumSequence() {
-      let sum = 0;
-      for (let i = 0; i < 5; i++) {
-        sum = sum + (await increment(i));
-      }
-      return sum;
-    }
-    sumSequence()
-  `);
-
-await mixedSandboxInterpreter.evaluateAsync(ts`
-    async function check(x) {
-      return x > 10;
-    }
-    async function classify(x) {
-      if (await check(x)) {
-        return "big";
-      } else {
-        return "small";
-      }
-    }
-    classify(15)
-  `);
+console.log({ hostAsync, asyncLoop, asyncArrow });

--- a/examples/environment-presets.ts
+++ b/examples/environment-presets.ts
@@ -1,24 +1,32 @@
-import { Interpreter } from "../src/interpreter";
-import { Browser, WinterCG, NodeJS, Minimal } from "../src/presets";
-import { ts } from "../src/utils";
+import { createSandbox } from "../src/index";
 
-const browserInterpreter = new Interpreter(Browser);
-browserInterpreter.evaluate(ts`typeof fetch`);
-browserInterpreter.evaluate(ts`typeof console`);
-browserInterpreter.evaluate(ts`typeof setTimeout`);
+const browser = createSandbox({ env: "browser" });
+const wintercg = createSandbox({ env: "wintercg" });
+const node = createSandbox({ env: "node" });
+const minimal = createSandbox({ env: "minimal" });
 
-const winterCGInterpreter = new Interpreter(WinterCG);
-winterCGInterpreter.evaluate(ts`typeof fetch`);
-winterCGInterpreter.evaluate(ts`typeof console`);
-winterCGInterpreter.evaluate(ts`typeof setTimeout`);
+const availability = {
+  browser: {
+    fetch: await browser.run<string>("typeof fetch"),
+    console: await browser.run<string>("typeof console"),
+    timers: await browser.run<string>("typeof setTimeout"),
+  },
+  wintercg: {
+    fetch: await wintercg.run<string>("typeof fetch"),
+    console: await wintercg.run<string>("typeof console"),
+    timers: await wintercg.run<string>("typeof setTimeout"),
+  },
+  node: {
+    fetch: await node.run<string>("typeof fetch"),
+    console: await node.run<string>("typeof console"),
+    timers: await node.run<string>("typeof setTimeout"),
+    arrayBuffer: await node.run<string>("typeof ArrayBuffer"),
+  },
+  minimal: {
+    math: await minimal.run<string>("typeof Math"),
+    fetch: await minimal.run<string>("typeof fetch"),
+    console: await minimal.run<string>("typeof console"),
+  },
+};
 
-const nodeJSInterpreter = new Interpreter(NodeJS);
-nodeJSInterpreter.evaluate(ts`typeof fetch`);
-nodeJSInterpreter.evaluate(ts`typeof console`);
-nodeJSInterpreter.evaluate(ts`typeof setTimeout`);
-nodeJSInterpreter.evaluate(ts`typeof ArrayBuffer`);
-
-const minimalInterpreter = new Interpreter(Minimal);
-minimalInterpreter.evaluate(ts`typeof Math`);
-minimalInterpreter.evaluate(ts`typeof fetch`);
-minimalInterpreter.evaluate(ts`typeof console`);
+console.log(availability);

--- a/examples/error-handling.ts
+++ b/examples/error-handling.ts
@@ -1,147 +1,44 @@
-import { Interpreter, ts } from "../src/index";
+import { createSandbox, ts } from "../src/index";
 
-const tryCatchInterpreter = new Interpreter();
+const sandbox = createSandbox({ env: "es2022" });
 
-tryCatchInterpreter.evaluate(ts`
-  let result = "not executed";
+const caught = await sandbox.run<string>(ts`
   try {
-    throw "Something went wrong!";
-    result = "success";
-  } catch {
-    result = "caught error";
+    throw "boom";
+  } catch (error) {
+    "caught " + error;
   }
-  result
 `);
 
-tryCatchInterpreter.evaluate(ts`
-  let result2;
-  try {
-    result2 = "success";
-  } catch {
-    result2 = "error";
-  }
-  result2
-`);
-
-tryCatchInterpreter.evaluate(ts`
-  let log = [];
-  try {
-    log.push("try");
-    throw "error";
-  } catch {
-    log.push("catch");
-  } finally {
-    log.push("finally");
-  }
-  log
-`);
-
-tryCatchInterpreter.evaluate(ts`
+const tryFinally = await sandbox.run<string[]>(ts`
+  const events = [];
   function test() {
-    let executed = [];
     try {
-      executed.push("try");
-      return executed;
-    } finally {
-      executed.push("finally");
-    }
-  }
-  test()
-`);
-
-tryCatchInterpreter.evaluate(ts`
-  function testOverride() {
-    try {
+      events.push("try");
       return "from try";
     } finally {
-      return "from finally";
+      events.push("finally");
     }
   }
-  testOverride()
+  test();
+  events;
 `);
 
-tryCatchInterpreter.evaluate(ts`
-  let log2 = [];
+const nested = await sandbox.run<string[]>(ts`
+  const events = [];
   try {
-    log2.push("outer try");
+    events.push("outer try");
     try {
-      log2.push("inner try");
-      throw "inner error";
+      throw "inner";
     } catch {
-      log2.push("inner catch");
-    }
-    log2.push("after inner");
-  } catch {
-    log2.push("outer catch");
-  }
-  log2
-`);
-
-tryCatchInterpreter.evaluate(ts`
-  let i2 = 0;
-  while (i2 < 10) {
-    try {
-      i2++;
-      if (i2 === 5) break;
+      events.push("inner catch");
     } finally {
+      events.push("inner finally");
     }
-  }
-  i2
-`);
-
-tryCatchInterpreter.evaluate(ts`
-  let sum2 = 0;
-  for (let i3 = 0; i3 < 10; i3++) {
-    try {
-      if (i3 % 2 === 0) continue;
-      sum2 = sum2 + i3;
-    } finally {
-    }
-  }
-  sum2
-`);
-
-tryCatchInterpreter.evaluate(ts`
-  let caughtError;
-  try {
-    throw "My custom error message";
-  } catch(e) {
-    caughtError = e;
-  }
-  caughtError
-`);
-
-tryCatchInterpreter.evaluate(ts`
-  function safeDivide(a, b) {
-    let result;
-    try {
-      if (b === 0) {
-        throw "Division by zero";
-      }
-      result = a / b;
-    } catch (e) {
-      result = "Error: " + e;
-    } finally {
-    }
-    return result;
-  }
-
-  let results = [];
-  results.push(safeDivide(10, 2));
-  results.push(safeDivide(10, 0));
-  results.push(safeDivide(15, 3));
-  results
-`);
-
-await tryCatchInterpreter.evaluateAsync(ts`
-  let log3 = [];
-  try {
-    log3.push("async try");
-    throw "async error";
-  } catch {
-    log3.push("async catch");
   } finally {
-    log3.push("async finally");
+    events.push("outer finally");
   }
-  log3
+  events;
 `);
+
+console.log({ caught, tryFinally, nested });

--- a/examples/globals.ts
+++ b/examples/globals.ts
@@ -1,42 +1,36 @@
-import { Interpreter, ts } from "../src/index";
+import { createSandbox, ts } from "../src/index";
 
-const interpreterWithGlobals = new Interpreter({
+const sandbox = createSandbox({
+  env: "es2022",
   globals: {
     PI: 3.14159,
     E: 2.71828,
-    MAX_ITERATIONS: 1000,
-  },
-});
-
-interpreterWithGlobals.evaluate(ts`
-  let radius = 10;
-  PI * radius * radius
-`);
-
-const interpreterForGlobals = new Interpreter();
-interpreterForGlobals.evaluate(ts`multiplier * value`, {
-  globals: { multiplier: 5, value: 20 },
-});
-
-const interpreterMerged = new Interpreter({ globals: { x: 10 } });
-interpreterMerged.evaluate(ts`x + y + z`, {
-  globals: { y: 20, z: 30 },
-});
-
-const interpreterWithConfig = new Interpreter({
-  globals: {
     config: {
       maxRetries: 3,
-      timeout: 5000,
       debug: true,
     },
   },
 });
 
-interpreterWithConfig.evaluate(ts`
-  let retries = 0;
-  while (retries < config.maxRetries) {
-    retries = retries + 1;
-  }
-  retries
+const area = await sandbox.run<number>(ts`
+  const radius = 10;
+  PI * radius * radius
 `);
+
+const perCall = await sandbox.run<number>("multiplier * value", {
+  globals: { multiplier: 5, value: 20 },
+});
+
+const merged = await sandbox.run<number>("x + y + z", {
+  globals: { x: 10, y: 20, z: 30 },
+});
+
+const retries = await sandbox.run<number>(ts`
+  let count = 0;
+  while (count < config.maxRetries) {
+    count = count + 1;
+  }
+  count
+`);
+
+console.log({ area, perCall, merged, retries });

--- a/examples/internal/interpreter.ts
+++ b/examples/internal/interpreter.ts
@@ -1,0 +1,18 @@
+import { ES2022, Interpreter, preset } from "../../src/index";
+
+const interpreter = new Interpreter(
+  preset(ES2022, {
+    globals: {
+      scale: (value: number, factor: number) => value * factor,
+    },
+    security: {
+      sanitizeErrors: true,
+      hideHostErrorMessages: true,
+    },
+  }),
+);
+
+const value = interpreter.evaluate("scale(7, 6)");
+const stats = interpreter.getStats();
+
+console.log({ value, stats });

--- a/examples/loops.ts
+++ b/examples/loops.ts
@@ -1,8 +1,8 @@
-import { Interpreter, ts } from "../src/index";
+import { createSandbox, ts } from "../src/index";
 
-const interpreter = new Interpreter();
+const sandbox = createSandbox({ env: "es2022" });
 
-interpreter.evaluate(ts`
+const oddSum = await sandbox.run<number>(ts`
   let sum = 0;
   for (let i = 0; i < 20; i++) {
     if (i > 15) {
@@ -16,28 +16,26 @@ interpreter.evaluate(ts`
   sum
 `);
 
-interpreter.evaluate(ts`
-  let isPrime = n => {
+const primeCount = await sandbox.run<number>(ts`
+  const isPrime = (n) => {
     if (n <= 1) {
-      return 0;
+      return false;
     }
     for (let i = 2; i * i <= n; i++) {
       if (n % i === 0) {
-        return 0;
+        return false;
       }
     }
-    return 1;
+    return true;
   };
 
-  let countPrimes = max => {
-    let count = 0;
-    for (let i = 2; i <= max; i++) {
-      if (isPrime(i)) {
-        count = count + 1;
-      }
+  let count = 0;
+  for (let i = 2; i <= 20; i++) {
+    if (isPrime(i)) {
+      count = count + 1;
     }
-    return count;
-  };
-
-  countPrimes(20)
+  }
+  count
 `);
+
+console.log({ oddSum, primeCount });

--- a/examples/objects.ts
+++ b/examples/objects.ts
@@ -1,81 +1,48 @@
-import { Interpreter, ts } from "../src/index";
+import { createSandbox, ts } from "../src/index";
 
-const interpreter = new Interpreter();
+const sandbox = createSandbox({ env: "es2022" });
 
-interpreter.evaluate(ts`
-  let people = [
+const totalAge = await sandbox.run<number>(ts`
+  const people = [
     { name: "Alice", age: 30 },
     { name: "Bob", age: 25 },
-    { name: "Charlie", age: 35 }
+    { name: "Charlie", age: 35 },
   ];
-  let totalAge = 0;
-  for (let i = 0; i < people.length; i++) {
-    totalAge = totalAge + people[i].age;
-  }
-  totalAge
+  people.reduce((sum, person) => sum + person.age, 0);
 `);
 
-interpreter.evaluate(ts`
-  let counter = {
+const counterValue = await sandbox.run<number>(ts`
+  const counter = {
     count: 0,
-    increment: function() {
+    increment() {
       this.count = this.count + 1;
       return this.count;
     },
-    decrement: function() {
+    decrement() {
       this.count = this.count - 1;
       return this.count;
     },
-    getCount: function() {
-      return this.count;
-    }
   };
-  counter.increment();
   counter.increment();
   counter.increment();
   counter.decrement();
-  counter.getCount()
+  counter.count;
 `);
 
-interpreter.evaluate(ts`
-  let rect = {
-    width: 10,
-    height: 5,
-    area: function() {
-      return this.width * this.height;
-    },
-    perimeter: function() {
-      return 2 * (this.width + this.height);
-    },
-    scale: function(factor) {
-      this.width = this.width * factor;
-      this.height = this.height * factor;
-      return this;
-    }
-  };
-  rect.scale(2);
-  rect.area()
-`);
-
-interpreter.evaluate(ts`
-  let cart = {
+const cartTotal = await sandbox.run<number>(ts`
+  const cart = {
     items: [],
-    total: 0,
-    addItem: function(price) {
-      let len = this.items.length;
-      this.items[len] = price;
-      this.total = this.total + price;
-      return this.total;
+    addItem(price) {
+      this.items.push(price);
     },
-    getTotal: function() {
-      return this.total;
+    total() {
+      return this.items.reduce((sum, item) => sum + item, 0);
     },
-    getItemCount: function() {
-      return this.items.length;
-    }
   };
   cart.addItem(10);
   cart.addItem(25);
   cart.addItem(15);
-  cart.getTotal()
+  cart.total();
 `);
+
+console.log({ totalAge, counterValue, cartTotal });

--- a/examples/recursion.ts
+++ b/examples/recursion.ts
@@ -1,31 +1,56 @@
-import { Interpreter, ts } from "../src/index";
+import { createSandbox, ts } from "../src/index";
 
-const interpreter = new Interpreter();
+const sandbox = createSandbox({ env: "es2022" });
 
-interpreter.evaluate(ts`
-  let factorial = n => {
+const factorial = await sandbox.run<number>(ts`
+  const factorial = (n) => {
     if (n <= 1) {
       return 1;
     }
     return n * factorial(n - 1);
   };
-  factorial(6)
+  factorial(6);
 `);
 
-interpreter.evaluate(ts`
-  let fib = n => {
+const fibonacci = await sandbox.run<number>(ts`
+  const fib = (n) => {
     if (n <= 1) {
       return n;
     }
     let a = 0;
     let b = 1;
-    let temp = 0;
     for (let i = 2; i <= n; i++) {
-      temp = a + b;
+      const next = a + b;
       a = b;
-      b = temp;
+      b = next;
     }
     return b;
   };
-  fib(10)
+  fib(10);
 `);
+
+const strictSandbox = createSandbox({
+  env: "es2022",
+  limits: {
+    perRun: {
+      callDepth: 25,
+    },
+  },
+});
+
+let depthLimitTriggered = false;
+try {
+  strictSandbox.runSync(ts`
+    const recurse = (n) => {
+      if (n === 0) {
+        return 0;
+      }
+      return recurse(n - 1) + 1;
+    };
+    recurse(40);
+  `);
+} catch {
+  depthLimitTriggered = true;
+}
+
+console.log({ factorial, fibonacci, depthLimitTriggered });

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "provenance": true
   },
   "scripts": {
+    "test": "bun test",
     "lint": "oxlint . --type-aware",
     "lint:fix": "oxlint . --type-aware --fix",
     "fmt": "oxfmt .",

--- a/test/sandbox-types.ts
+++ b/test/sandbox-types.ts
@@ -1,0 +1,28 @@
+import { createSandbox, type RunResult, run } from "../src/sandbox";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+const sandbox = createSandbox({ env: "es2022" });
+
+const sandboxValue = sandbox.run<number>("1 + 2");
+type SandboxValueType = Awaited<typeof sandboxValue>;
+type AssertSandboxValue = Expect<Equal<SandboxValueType, number>>;
+
+const sandboxFull = sandbox.run<number>("1 + 2", { result: "full" });
+type SandboxFullType = Awaited<typeof sandboxFull>;
+type AssertSandboxFull = Expect<Equal<SandboxFullType, RunResult<number>>>;
+
+const oneOffValue = run<number>("1 + 2");
+type OneOffValueType = Awaited<typeof oneOffValue>;
+type AssertOneOffValue = Expect<Equal<OneOffValueType, number>>;
+
+const oneOffFull = run<number>("1 + 2", { result: "full" });
+type OneOffFullType = Awaited<typeof oneOffFull>;
+type AssertOneOffFull = Expect<Equal<OneOffFullType, RunResult<number>>>;
+
+void ({} as AssertSandboxValue);
+void ({} as AssertSandboxFull);
+void ({} as AssertOneOffValue);
+void ({} as AssertOneOffFull);


### PR DESCRIPTION
## Summary

This PR improves the simplified sandbox API (`createSandbox`, `run`, `runModule`) across three areas:

1. Safer default runtime behavior for untrusted code execution.
2. Better API ergonomics with first-class async timeout controls and typed run overloads.
3. Clearer onboarding by shifting examples/docs toward the recommended simplified API.

## Why

The package already had strong security primitives and broad feature coverage, but there were gaps in day-to-day usability:

- Easy-to-miss guardrails (limits/timeouts) for untrusted code execution.
- Reduced type ergonomics around run return values.
- Examples mixed internal and recommended APIs, increasing onboarding friction.

This PR addresses those without changing the low-level interpreter model.

## What Changed

### 1) Simplified API runtime safety defaults

`createSandbox()` now applies safe per-run defaults unless explicitly overridden:

- `callDepth: 250`
- `loops: 100_000`
- `memoryBytes: 16 * 1024 * 1024`

These are merged with user-specified `limits.perRun`, so explicit configuration still wins.

### 2) First-class `timeoutMs` support

Added `timeoutMs` to simplified sandbox options:

- sandbox-level default: `createSandbox({ timeoutMs: ... })`
- per-call override: `sandbox.run(code, { timeoutMs: ... })`

Behavior:

- Supported for async `run()` and `runModule()`.
- Combined with existing `AbortSignal` (whichever aborts first cancels execution).
- Explicitly rejected in `runSync()` with a clear error message.

### 3) Typed result overloads

Added generic overloads for stronger type inference and explicit type targeting:

- `sandbox.run<T>()`
- `sandbox.runSync<T>()`
- `sandbox.runModule<T>()`
- top-level `run<T>()`

`result: "full"` overloads preserve typed `RunResult<T>`.

### 4) Example reorganization and cleanup

Examples now primarily use the recommended simplified API and are easier to follow for first-time adopters.

- Migrated all top-level example files to `createSandbox`/`run`.
- Added `examples/README.md` to separate recommended examples from advanced usage.
- Added `examples/internal/interpreter.ts` for explicit internal API usage.

### 5) Documentation updates

Updated docs to reflect new defaults and timeout flow:

- `README.md`: safe defaults, first-class timeouts, examples link.
- `docs/SIMPLIFIED_API.md`: `timeoutMs`, default limits, typed run helpers.
- `docs/SECURITY.md`: execution limits section now documents default guardrails and timeout usage.
- `docs/INTERNAL_CLASSES.md`: points to advanced internal example path.

### 6) DX and release metadata

- Added `"test": "bun test"` script in `package.json`.
- Added changeset documenting API/docs behavior updates.

## Behavioral Notes

This is intentionally safer-by-default. Existing integrations that relied on effectively unbounded recursion/loops/memory in simplified API calls may now hit limits unless they override `limits.perRun`.

Also, passing `timeoutMs` to `runSync` now throws by design.

## Test Coverage Added

Added simplified API tests for:

- default call-depth enforcement
- explicit override of default limits
- per-run async `timeoutMs` cancellation
- sandbox-level default timeout behavior
- sync rejection when `timeoutMs` is supplied

Added type-level checks for generic run overload return types.

## Validation Performed

- `bun run fmt`
- `bun run lint`
- `bun run typecheck`
- `bun test`
- `bun run build`

All passed.

## Key Files for Review

- `/Users/samuellaycock/Development/nookjs/src/sandbox.ts`
- `/Users/samuellaycock/Development/nookjs/test/sandbox-api.test.ts`
- `/Users/samuellaycock/Development/nookjs/test/sandbox-types.ts`
- `/Users/samuellaycock/Development/nookjs/examples/README.md`
- `/Users/samuellaycock/Development/nookjs/examples/internal/interpreter.ts`
- `/Users/samuellaycock/Development/nookjs/docs/SIMPLIFIED_API.md`
- `/Users/samuellaycock/Development/nookjs/docs/SECURITY.md`
- `/Users/samuellaycock/Development/nookjs/README.md`
- `/Users/samuellaycock/Development/nookjs/package.json`

## Follow-ups

- Add CI/package smoke tests that validate built `dist` exports against documented simplified API entrypoints.
