### PR TITLE
fix: throw when named re-export is missing in source module

### DIFF
--- a/.changeset/large-gifts-jam.md
+++ b/.changeset/large-gifts-jam.md
@@ -1,0 +1,7 @@
+---
+"nookjs": patch
+---
+
+Fix missing-name validation for named re-exports.
+
+`export { missing } from "source.js"` now throws when the source module does not export the requested binding, matching named import validation behavior.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -3773,7 +3773,11 @@ export class Interpreter {
 
         for (const spec of node.specifiers) {
           if (spec.type === "ExportSpecifier") {
-            const value = sourceExports[spec.local.name];
+            const importedName = spec.local.name;
+            if (!(importedName in sourceExports)) {
+              throw new InterpreterError(`Module '${specifier}' does not export '${importedName}'`);
+            }
+            const value = sourceExports[importedName];
             exports[spec.exported.name] = value;
           }
         }

--- a/test/modules.test.ts
+++ b/test/modules.test.ts
@@ -1639,6 +1639,19 @@ describe("Module System", () => {
         expect(result.myDefault).toBe(99);
       });
 
+      test("should throw when re-exporting a missing named export", async () => {
+        const files = new Map([["source.js", "export const a = 1;"]]);
+        const interpreter = new Interpreter({
+          modules: { enabled: true, resolver: createResolver(files) },
+        });
+
+        expect(
+          interpreter.evaluateModuleAsync(`export { missing } from "source.js";`, {
+            path: "main.js",
+          }),
+        ).rejects.toThrow("Module 'source.js' does not export 'missing'");
+      });
+
       test("should re-export from multiple sources", async () => {
         const files = new Map([
           ["a.js", "export const fromA = 1;"],


### PR DESCRIPTION
## Summary
Fixes a module-system bug where `export { missing } from "source.js"` silently exported `undefined` instead of throwing.

Fixes #53

## Changes
- add missing-name validation for named re-exports in `ExportNamedDeclaration` (`export { x } from "..."`)
- throw `Module '<specifier>' does not export '<name>'` when the source module does not provide the requested export
- add regression test covering missing-name re-export behavior
- add patch changeset

## Validation
- bun run fmt
- bun run lint:fix
- bun test
- bun run typecheck
- bun test test/modules.test.ts -t "should throw when re-exporting a missing named export"
- bun test test/modules.test.ts -t "export { } from"
