### PR TITLE
fix: persist failed module state and avoid repeated re-evaluation

### DIFF
--- a/.changeset/calm-pets-sing.md
+++ b/.changeset/calm-pets-sing.md
@@ -1,0 +1,7 @@
+---
+"nookjs": patch
+---
+
+Fix module failure caching state so failed modules are tracked as `failed` instead of remaining `initializing`.
+
+Failed module parse/evaluation now updates metadata with the stored error and reuses the failed cache record on subsequent imports, avoiding repeated re-evaluation attempts.

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -255,6 +255,10 @@ export class ModuleSystem {
           if (existingByPath.status === "initializing") {
             return existingByPath;
           }
+          // If previously failed, return cached failure record
+          if (existingByPath.status === "failed") {
+            return existingByPath;
+          }
         }
       }
 


### PR DESCRIPTION
## Summary
Fixes module failure caching so failed modules are marked as `failed` (not left `initializing`) and are not re-evaluated on subsequent imports.

Fixes #54

## Changes
- in `resolveModuleExports`, handle module statuses explicitly:
  - return exports for `initialized`
  - throw stored error for `failed`
  - on `initializing`, parse/evaluate in a try/catch and call `setModuleFailed` on error before rethrow
- in `ModuleSystem.resolveModule`, return cached `failed` records instead of recreating fresh `initializing` records
- strengthen regression test to verify:
  - metadata status becomes `failed`
  - metadata error is stored
  - repeated imports of the same failed module do not re-run module side effects
- add patch changeset

## Validation
- bun run fmt
- bun run lint:fix
- bun test
- bun run typecheck
- bun test test/modules.test.ts -t "should track failed module in metadata"
- bun test test/modules.test.ts -t "Introspection Edge Cases|Lifecycle Hook|cache"
