### PR TITLE
feat: add opt-in strict evaluation isolation for mixed sync/async runs

### DIFF
--- a/.changeset/tame-masks-tie.md
+++ b/.changeset/tame-masks-tie.md
@@ -1,0 +1,7 @@
+---
+"nookjs": patch
+---
+
+Add opt-in strict evaluation isolation to serialize mixed sync/async access safely.
+
+When `strictEvaluationIsolation: true` is set on `Interpreter` (or `createSandbox`), synchronous `evaluate()` / `runSync()` calls are blocked while async/module evaluations are pending, preventing shared-state races between sync and async runs on the same instance.

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -144,6 +144,7 @@ export interface SandboxOptions {
   readonly validator?: (ast: ESTree.Program) => boolean;
   readonly trackResources?: boolean;
   readonly security?: SecurityOptions;
+  readonly strictEvaluationIsolation?: boolean;
 }
 
 export interface RunOptions {
@@ -578,6 +579,7 @@ export const createSandbox = (options: SandboxOptions = {}): Sandbox => {
     ...(featureControl ? { featureControl } : {}),
     ...(trackResources ? { resourceTracking: true } : {}),
     ...(options.validator ? { validator: options.validator } : {}),
+    ...(options.strictEvaluationIsolation ? { strictEvaluationIsolation: true } : {}),
     globals: {
       ...baseOptions.globals,
       ...options.globals,

--- a/test/strict-isolation.test.ts
+++ b/test/strict-isolation.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "bun:test";
+
+import { Interpreter } from "../src/interpreter";
+import { createSandbox } from "../src/sandbox";
+
+describe("Strict Evaluation Isolation", () => {
+  it("should block sync evaluate() while async evaluation is pending", async () => {
+    const gateState: { release: () => void } = { release: () => {} };
+    const gate = new Promise<void>((resolve) => {
+      gateState.release = resolve;
+    });
+
+    const waitForGate = () => gate;
+    const interpreter = new Interpreter({ strictEvaluationIsolation: true });
+
+    const asyncRun = interpreter.evaluateAsync(
+      `
+        async function readSecret() {
+          await waitForGate();
+          return secret;
+        }
+
+        readSecret();
+      `,
+      {
+        globals: { waitForGate, secret: "A" },
+      },
+    );
+
+    const syncRun: { error: unknown } = { error: undefined };
+    try {
+      interpreter.evaluate("secret", { globals: { secret: "B" } });
+    } catch (error) {
+      syncRun.error = error;
+    } finally {
+      gateState.release();
+    }
+
+    const syncErrorMessage =
+      syncRun.error instanceof Error ? syncRun.error.message : String(syncRun.error);
+    expect(syncErrorMessage).toContain("Strict isolation is enabled");
+    const asyncResult = await asyncRun;
+    expect(asyncResult).toBe("A");
+  });
+
+  it("should block runSync() while run() is pending when enabled via createSandbox()", async () => {
+    const gateState: { release: () => void } = { release: () => {} };
+    const gate = new Promise<void>((resolve) => {
+      gateState.release = resolve;
+    });
+
+    const waitForGate = () => gate;
+    const sandbox = createSandbox({
+      env: "es2022",
+      strictEvaluationIsolation: true,
+      globals: { waitForGate },
+    });
+
+    const asyncRun = sandbox.run(
+      `
+        async function readSecret() {
+          await waitForGate();
+          return secret;
+        }
+
+        readSecret();
+      `,
+      {
+        globals: { secret: "A" },
+      },
+    );
+
+    const syncRun: { error: unknown } = { error: undefined };
+    try {
+      sandbox.runSync("secret", { globals: { secret: "B" } });
+    } catch (error) {
+      syncRun.error = error;
+    } finally {
+      gateState.release();
+    }
+
+    const syncErrorMessage =
+      syncRun.error instanceof Error ? syncRun.error.message : String(syncRun.error);
+    expect(syncErrorMessage).toContain("Strict isolation is enabled");
+    const asyncResult = await asyncRun;
+    expect(asyncResult).toBe("A");
+  });
+});


### PR DESCRIPTION
## Summary
- add a new `strictEvaluationIsolation` option on `InterpreterOptions`
- enforce strict mode by blocking `evaluate()` when any evaluation is already pending
- keep `evaluateAsync()` and `evaluateModuleAsync()` serialized through the existing mutex
- expose the same option through `createSandbox()` via `SandboxOptions.strictEvaluationIsolation`
- add regression tests for interpreter and sandbox mixed sync/async overlap behavior
- add a changeset describing the new strict isolation behavior

## Why
Issue #55 reported that sync `evaluate()` can overlap async runs and mutate shared state. This PR adds an opt-in strict isolation mode that prevents those overlaps.

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`

## Changeset
- `.changeset/tame-masks-tie.md`

Closes #55
