### PR TITLE
docs: clarify JS compatibility for division/modulo by zero

### DIFF
--- a/.changeset/gold-gifts-jog.md
+++ b/.changeset/gold-gifts-jog.md
@@ -1,0 +1,7 @@
+---
+"nookjs": patch
+---
+
+Clarify JavaScript compatibility expectations for arithmetic edge cases.
+
+This updates package and documentation wording to explicitly call out that division/modulo by zero intentionally throws `InterpreterError` rather than using native JS `Infinity`/`NaN` results.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ NookJS is a JavaScript interpreter designed for safely executing untrusted code 
 - **Global Injection**: Safe injection of host functions and data with property access protection
 - **Zero Dependencies**: Custom AST parser with no runtime dependencies
 
+### Compatibility Note
+
+NookJS prioritizes sandbox safety and predictable host isolation over exact native-JavaScript parity in every edge case. Some behaviors are intentionally different from native JS semantics.
+
+One important example: division/modulo by zero throws `InterpreterError` instead of returning `Infinity`, `-Infinity`, or `NaN`.
+
+See [Limitations](#limitations) for the full list of known semantic differences.
+
 ### Use Cases
 
 - **Plugin Systems**: Allow users to write custom logic without compromising security

--- a/docs/BINARY_OPERATORS.md
+++ b/docs/BINARY_OPERATORS.md
@@ -23,6 +23,6 @@ Binary operations such as `+`, `-`, comparisons, bitwise operators, and `**`.
 
 - `in` requires the right-hand side to be an object.
 - `instanceof` supports host constructors, `ClassValue`, and `FunctionValue` instances.
-- Division/modulo by zero throws an `InterpreterError`.
+- Division/modulo by zero intentionally throws an `InterpreterError` (native JS would produce infinities/NaN).
 - String concatenation with `+` coerces the other operand to a string.
 - Exponentiation (`**`) has right-to-left associativity: `2 ** 3 ** 2` = `2 ** (3 ** 2)` = `512`.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nookjs",
   "version": "0.4.1",
-  "description": "A fast(ish), standards-compliant JavaScript/TypeScript(ish) parser and interpreter written in TypeScript.",
+  "description": "A fast(ish), security-focused JavaScript/TypeScript(ish) parser and interpreter with documented semantic deviations.",
   "homepage": "https://nookjs.dev",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- remove "standards-compliant" phrasing from package metadata to avoid implying exact semantic parity
- add a top-level compatibility note in the README near the project introduction
- explicitly call out the intentional division/modulo by zero behavior (`InterpreterError` vs native JS `Infinity`/`NaN`)
- tighten wording in binary operators documentation to mark the behavior as intentional
- add a changeset for this clarification update

## Why
Issue #56 points out that arithmetic semantics differ from native JavaScript while package/docs wording can be read as strict standards parity. This PR keeps runtime behavior unchanged and makes that deviation explicit up front.

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`

## Changeset
- `.changeset/gold-gifts-jog.md`

Closes #56
