### PR TITLE
refactor(ast): remove unused parseScript/parseModule options

### DIFF
--- a/.changeset/fast-rules-double.md
+++ b/.changeset/fast-rules-double.md
@@ -1,0 +1,7 @@
+---
+"nookjs": patch
+---
+
+Remove unused `parseScript` and `parseModule` options parameters in the AST parser API.
+
+These options were accepted but ignored. The signatures now match runtime behavior, and related interpreter call sites were updated to call the parser helpers without no-op options.

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -3,11 +3,6 @@ export interface Location {
   end: { line: number; column: number };
 }
 
-interface ParseOptions {
-  readonly next?: boolean;
-  readonly profile?: boolean;
-}
-
 interface ParseProfile {
   readonly tokens: number;
   readonly tokenizeMs: number;
@@ -4178,12 +4173,12 @@ class Parser {
   }
 }
 
-export function parseModule(input: string, _options: ParseOptions = {}): ESTree.Program {
+export function parseModule(input: string): ESTree.Program {
   const parser = new Parser(input, true);
   return parser.parseProgram();
 }
 
-export function parseScript(input: string, _options: ParseOptions = {}): ESTree.Program {
+export function parseScript(input: string): ESTree.Program {
   const parser = new Parser(input, false);
   return parser.parseProgram();
 }

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -3096,12 +3096,7 @@ export class Interpreter {
     input: string | ESTree.Program,
     options?: EvaluateOptions,
   ): ESTree.Program {
-    const ast =
-      typeof input === "string"
-        ? parseScript(input, {
-            next: true,
-          })
-        : input;
+    const ast = typeof input === "string" ? parseScript(input) : input;
 
     this.validateAst(ast, options);
     this.ensureNoTopLevelAwait(ast);
@@ -3113,12 +3108,7 @@ export class Interpreter {
     input: string | ESTree.Program,
     options?: EvaluateOptions,
   ): ESTree.Program {
-    const ast =
-      typeof input === "string"
-        ? parseModule(input, {
-            next: true,
-          })
-        : input;
+    const ast = typeof input === "string" ? parseModule(input) : input;
 
     this.validateAst(ast, options);
 
@@ -3255,7 +3245,7 @@ export class Interpreter {
    * ```
    */
   parse(code: string, options?: ParseOptions): ESTree.Program {
-    const ast = parseScript(code, { next: true });
+    const ast = parseScript(code);
 
     if (options?.validator) {
       const isValid = options.validator(ast);
@@ -3883,7 +3873,7 @@ export class Interpreter {
       // Module is initializing; evaluate its AST now to populate exports.
       let ast: ESTree.Program;
       if (moduleRecord.source !== undefined) {
-        ast = parseModule(moduleRecord.source, { next: true });
+        ast = parseModule(moduleRecord.source);
       } else if (moduleRecord.ast) {
         ast = moduleRecord.ast;
       } else {

--- a/test/ast-types.ts
+++ b/test/ast-types.ts
@@ -1,0 +1,14 @@
+import { parseModule, parseScript } from "../src/ast";
+
+type Equal<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2 ? true : false;
+type Expect<T extends true> = T;
+
+type ParseScriptParams = Parameters<typeof parseScript>;
+type AssertParseScriptParams = Expect<Equal<ParseScriptParams, [input: string]>>;
+
+type ParseModuleParams = Parameters<typeof parseModule>;
+type AssertParseModuleParams = Expect<Equal<ParseModuleParams, [input: string]>>;
+
+void ({} as AssertParseScriptParams);
+void ({} as AssertParseModuleParams);


### PR DESCRIPTION
## Summary
- remove the unused options parameter from `parseScript()` and `parseModule()` in `src/ast.ts`
- update interpreter parser call sites to stop passing no-op options
- add a type-level regression test (`test/ast-types.ts`) to lock both parser helper signatures to a single input argument
- add a changeset for the parser API cleanup

## Why
Issue #57 identified that `parseScript(input, _options)` and `parseModule(input, _options)` accepted options but ignored them. Keeping dead parameters makes the API misleading and increases risk for callers assuming those options are honored.

This PR takes the “remove unused options” path so signatures match actual behavior.

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`

## Changeset
- `.changeset/fast-rules-double.md`

Closes #57
