### PR TITLE
test(modules): add regression tests for issue #58

### DIFF
--- a/.changeset/nice-mangos-taste.md
+++ b/.changeset/nice-mangos-taste.md
@@ -1,0 +1,7 @@
+---
+"nookjs": patch
+---
+
+Add explicit module-system regression coverage for circular imports and missing named re-exports.
+
+This adds tests for a direct `a -> b -> a` circular chain and for aliased missing re-exports (`export { missing as renamed } from ...`) to guard against regressions in ESM resolution and export validation.


### PR DESCRIPTION
## Summary
- add regression coverage for a direct `a -> b -> a` circular dependency chain
- add regression coverage for missing-name re-export validation when aliasing (`export { missing as renamed } from ...`)
- include a changeset for the new regression test coverage

## Why
Issue #58 requests explicit regression tests for two critical module correctness cases:
1. True circular dependency behavior
2. Missing-name re-export validation

These tests lock in behavior that has regressed before and makes failures easier to catch in future changes.

## Testing
- `bun run test test/modules.test.ts`
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`

## Changeset
- `.changeset/nice-mangos-taste.md`

Closes #58
