### PR TITLE
chore(ci): pin toolchain versions and frozen installs

### DIFF
--- a/.changeset/new-bats-think.md
+++ b/.changeset/new-bats-think.md
@@ -1,0 +1,7 @@
+---
+"nookjs": patch
+---
+
+Pin CI/release toolchain versions and enforce frozen lockfile installs.
+
+This pins GitHub Actions Bun setup versions, pins the website deploy Wrangler action version, pins `@types/bun` in `package.json`, and updates workflow install steps to use `bun install --frozen-lockfile` for more reproducible CI and release runs.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.7
 
       - name: Setup NPM
         uses: actions/setup-node@v4

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.7
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run lint check
         run: bun lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.7
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Run test suite
         run: bun test

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -23,10 +23,10 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.7
 
       - name: Install dependencies
-        run: bun install
+        run: bun install --frozen-lockfile
 
       - name: Build website
         run: bun run check
@@ -35,5 +35,5 @@ jobs:
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          wranglerVersion: latest
+          wranglerVersion: 4.61.1
           workingDirectory: www

--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "name": "interpreter",
       "devDependencies": {
         "@changesets/cli": "^2.29.8",
-        "@types/bun": "latest",
+        "@types/bun": "1.3.7",
         "meriyah": "7.1.0",
         "oxfmt": "0.28.0",
         "oxlint": "1.43.0",
@@ -171,7 +171,7 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
-    "@types/bun": ["@types/bun@1.3.8", "", { "dependencies": { "bun-types": "1.3.8" } }, "sha512-3LvWJ2q5GerAXYxO2mffLTqOzEu5qnhEAlh48Vnu8WQfnmSwbgagjGZV6BoHKJztENYEDn6QmVd949W4uESRJA=="],
+    "@types/bun": ["@types/bun@1.3.7", "", { "dependencies": { "bun-types": "1.3.7" } }, "sha512-lmNuMda+Z9b7tmhA0tohwy8ZWFSnmQm1UDWXtH5r9F7wZCfkeO3Jx7wKQ1EOiKq43yHts7ky6r8SDJQWRNupkA=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -197,7 +197,7 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
-    "bun-types": ["bun-types@1.3.8", "", { "dependencies": { "@types/node": "*" } }, "sha512-fL99nxdOWvV4LqjmC+8Q9kW3M4QTtTR1eePs94v5ctGqU8OeceWrSUaRw3JYb7tU3FkMIAjkueehrHPPPGKi5Q=="],
+    "bun-types": ["bun-types@1.3.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-qyschsA03Qz+gou+apt6HNl6HnI+sJJLL4wLDke4iugsE6584CMupOtTY1n+2YC9nGVrEKUlTs99jjRLKgWnjQ=="],
 
     "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.29.8",
-    "@types/bun": "latest",
+    "@types/bun": "1.3.7",
     "meriyah": "7.1.0",
     "oxfmt": "0.28.0",
     "oxlint": "1.43.0",


### PR DESCRIPTION
## Summary
- pin `setup-bun` version to `1.3.7` in CI/release workflows (`test`, `quality`, `website`, `publish`)
- switch CI install steps to `bun install --frozen-lockfile` where non-frozen installs were used
- pin `wranglerVersion` in website deploy workflow to `4.61.1`
- pin `@types/bun` to `1.3.7` in `package.json` and refresh `bun.lock`
- add a changeset for the toolchain/CI reproducibility update

## Why
Issue #59 calls out drift risk from moving `latest` toolchain tags and non-frozen dependency installs in CI/release paths. This PR pins versions and enforces lockfile usage for more reproducible builds and easier failure diagnosis.

## Testing
- `bun install`
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`

## Changeset
- `.changeset/new-bats-think.md`

Closes #59
