### PR TITLE
docs(contributing): update stale project structure paths

### DIFF
--- a/.changeset/fair-badgers-heal.md
+++ b/.changeset/fair-badgers-heal.md
@@ -1,0 +1,7 @@
+---
+"nookjs": patch
+---
+
+Update stale project-structure paths in `CONTRIBUTING.md`.
+
+This refreshes the structure examples to match the current repository layout (`src/index.ts`, `test/` directory, current source modules) and fixes outdated `tests/` references in the contribution workflow.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,12 +67,15 @@ nookjs/
 ├── src/                  # Source code
 │   ├── ast.ts           # AST parser
 │   ├── interpreter.ts   # Main interpreter
-│   ├── values.ts        # Value types
-│   └── ...
+│   ├── modules.ts       # ES module system
+│   ├── sandbox.ts       # Simplified sandbox API
+│   ├── resource-tracker.ts
+│   └── index.ts         # Package entry point exports
+├── test/                # Test files
 ├── docs/                # Documentation
-├── tests/               # Test files
 ├── conventions/         # Development conventions
-└── index.ts             # Entry point
+├── package.json         # Scripts + package metadata
+└── bun.lock             # Locked dependency versions
 ```
 
 ## Conventions
@@ -92,7 +95,7 @@ To add support for a new JavaScript feature:
 
 1. **Parse**: Add the AST node type to `src/ast.ts` parser
 2. **Evaluate**: Add evaluation logic in `src/interpreter.ts`
-3. **Test**: Add comprehensive tests in `tests/`
+3. **Test**: Add comprehensive tests in `test/`
 4. **Document**: Update `docs/README.md` with feature details
 
 ### Security Considerations


### PR DESCRIPTION
## Summary
- update `CONTRIBUTING.md` project-structure section to match current repository layout
- replace stale paths (`src/values.ts`, `tests/`, root `index.ts`) with current paths (`src/index.ts`, `test/`, active source modules)
- align the feature workflow guidance to reference `test/` instead of `tests/`
- add a changeset for this documentation fix

## Why
Issue #60 identifies stale structure paths in contribution docs. This PR makes the contributor guide match the real tree so new contributors can navigate the repo correctly.

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`

## Changeset
- `.changeset/fair-badgers-heal.md`

Closes #60
