### PR TITLE
fix: support iterable spread arguments in call expressions

### DIFF
--- a/.changeset/fair-jars-rhyme.md
+++ b/.changeset/fair-jars-rhyme.md
@@ -1,0 +1,11 @@
+---
+"nookjs": patch
+---
+
+Support iterable spread arguments in call expressions so call spread behavior matches native JavaScript more closely.
+
+- Expand call spread arguments from generic iterables/iterators (including strings, Sets, Map iterators, and custom iterables), not just arrays.
+- Keep sync and async argument evaluation paths aligned by using the same iterable validation logic.
+- Preserve clear runtime errors for non-iterable spread values.
+- Add regression coverage for iterable call spread success/failure cases and async call spread behavior.
+- Update call/spread docs to reflect iterable support in call position.

--- a/docs/CALL_EXPRESSION.md
+++ b/docs/CALL_EXPRESSION.md
@@ -13,6 +13,6 @@ Function calls like `fn()` or `obj.method()`.
 
 ## Gotchas
 
-- Spread arguments in calls must be arrays (iterables are not expanded in call position).
+- Spread arguments in calls accept iterables and iterators (arrays, strings, generators, Sets, etc.).
 - Async host functions require `evaluateAsync`.
 - `call`/`apply`/`bind` are blocked on host functions.

--- a/docs/SPREAD_OPERATOR.md
+++ b/docs/SPREAD_OPERATOR.md
@@ -8,7 +8,7 @@ Spread syntax in arrays, objects, and call expressions.
 
 - Array spread uses `validateArraySpread` and `iterableToArray`.
 - Object spread requires a non-null, non-array object via `validateObjectSpread`.
-- Call spread expands arrays only.
+- Call spread expands iterables and iterators.
 
 ## Gotchas
 

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -5709,17 +5709,15 @@ export class Interpreter {
     for (let i = 0; i < count; i++) {
       const arg = args[i];
       if (arg?.type === "SpreadElement") {
-        // Spread in call: fn(...arr) - expand array as separate arguments.
+        // Spread in call: fn(...iterable) - expand iterable items as separate arguments.
         if (!this.isFeatureEnabled("SpreadOperator")) {
           throw new InterpreterError("SpreadOperator is not enabled");
         }
 
         const spreadValue = this.evaluateNode((arg as ESTree.SpreadElement).argument);
-        if (!Array.isArray(spreadValue)) {
-          throw new InterpreterError("Spread syntax in function calls requires an array");
-        }
-        // Avoid push(...spreadValue) to sidestep argument count limits on large arrays.
-        this.appendSpreadArgs(evaluatedArgs, spreadValue);
+        const spreadArray = this.validateArraySpread(spreadValue);
+        // Avoid push(...spreadArray) to sidestep argument count limits on large arrays.
+        this.appendSpreadArgs(evaluatedArgs, spreadArray);
       } else {
         evaluatedArgs.push(this.evaluateNode(arg as ESTree.Expression));
       }
@@ -5756,17 +5754,15 @@ export class Interpreter {
     for (let i = 0; i < count; i++) {
       const arg = args[i];
       if (arg?.type === "SpreadElement") {
-        // Spread in call: fn(...arr) - expand array as separate arguments.
+        // Spread in call: fn(...iterable) - expand iterable items as separate arguments.
         if (!this.isFeatureEnabled("SpreadOperator")) {
           throw new InterpreterError("SpreadOperator is not enabled");
         }
 
         const spreadValue = await this.evaluateNodeAsync((arg as ESTree.SpreadElement).argument);
-        if (!Array.isArray(spreadValue)) {
-          throw new InterpreterError("Spread syntax in function calls requires an array");
-        }
-        // Avoid push(...spreadValue) to sidestep argument count limits on large arrays.
-        this.appendSpreadArgs(evaluatedArgs, spreadValue);
+        const spreadArray = this.validateArraySpread(spreadValue);
+        // Avoid push(...spreadArray) to sidestep argument count limits on large arrays.
+        this.appendSpreadArgs(evaluatedArgs, spreadArray);
       } else {
         let val = await this.evaluateNodeAsync(arg as ESTree.Expression);
         // Unwrap RawValue (used to prevent Promise auto-awaiting from call/new expressions)


### PR DESCRIPTION
## Summary
This PR fixes call-expression spread so it accepts generic iterables/iterators, not just arrays.

Closes #79.

## What Changed
- Updated call argument evaluation in both sync and async interpreter paths to use shared iterable validation for spread elements.
- Call spread now expands iterable values such as strings, Sets, Map iterators, and custom iterables.
- Preserved clear non-iterable failures using the existing iterable-required error path.
- Added regression coverage in test/variables.test.ts for:
  - string spread in calls
  - Set spread in calls
  - Map iterator spread in calls
  - custom iterable spread in calls
  - non-iterable failure cases
  - async call spread behavior
- Updated docs:
  - docs/CALL_EXPRESSION.md
  - docs/SPREAD_OPERATOR.md
- Added patch changeset:
  - .changeset/fair-jars-rhyme.md

## Validation
- bun fmt
- bun lint:fix
- bun test
- bun typecheck
