### PR TITLE
feat(modules): support dynamic import() in module evaluation

### DIFF
--- a/.changeset/slow-pumas-reflect.md
+++ b/.changeset/slow-pumas-reflect.md
@@ -1,0 +1,7 @@
+---
+"nookjs": minor
+---
+
+Add support for dynamic `import()` expressions in async evaluation paths.
+
+This introduces parser and interpreter support for `ImportExpression`, routes dynamic imports through the existing module resolver and cache logic, and enforces module authorization/depth limits consistently with static imports. It also updates ES2020+ preset feature flags and module documentation, plus adds regression tests for parsing, success paths, blocked imports, max depth, and caching behavior.

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -454,7 +454,7 @@ const sandbox = createSandbox({
 
 ## Differences from Native ES Modules
 
-1. **No dynamic import()**: The `import()` expression is not supported
+1. **Dynamic import is async-only**: Use `import()` from async contexts (e.g. `await import("./mod.js")`)
 2. **No import.meta**: The `import.meta` object is not available
 3. **Synchronous resolution**: While resolver can be async, module graph is built before execution
 4. **Custom resolution**: No automatic Node.js-style resolution (you control it via resolver)

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -253,7 +253,7 @@ export const ES2019: InterpreterOptions = {
  * - BigInt (via globals)
  * - Promise.allSettled() (on Promise)
  * - globalThis (via globals)
- * - Dynamic import (not applicable)
+ * - Dynamic import (import())
  *
  * Note: Nullish coalescing is included under LogicalOperators in all presets.
  */
@@ -265,6 +265,7 @@ export const ES2020: InterpreterOptions = {
       ...(ES2019.featureControl!.features as LanguageFeature[]),
       "OptionalChaining",
       "BigIntLiteral",
+      "DynamicImport",
     ],
   },
   globals: {

--- a/test/ast.test.ts
+++ b/test/ast.test.ts
@@ -195,6 +195,14 @@ describe("AST", () => {
         expect(comp.type).toBe("MemberExpression");
         expect((comp as ESTree.MemberExpression).computed).toBe(true);
       });
+
+      it("parses dynamic import expressions", () => {
+        const dynamicImport = parseFirstExpression('import("./dep.js");');
+        expect(dynamicImport.type).toBe("ImportExpression");
+        const importExpression = dynamicImport as ESTree.ImportExpression;
+        expect(importExpression.source.type).toBe("Literal");
+        expect((importExpression.source as ESTree.Literal).value).toBe("./dep.js");
+      });
     });
 
     describe("Functions and arrows", () => {


### PR DESCRIPTION
## Summary
Adds support for dynamic `import()` expressions in the interpreter when modules are enabled.

Closes #80.

## What changed
- Added parser support for `ImportExpression` in `/src/ast.ts`.
  - `import(` is now parsed as an expression, while `import ... from` remains a declaration.
- Added interpreter runtime support for `import()` in `/src/interpreter.ts`.
  - Added `DynamicImport` language feature flag.
  - Added async `ImportExpression` evaluation path.
  - Dynamic imports now resolve via the existing module resolver/cache code path (`resolveModuleExports`) and return a Promise-like namespace object.
  - Dynamic imports in sync `evaluate()` now raise a clear error directing callers to `evaluateAsync()`.
- Updated ES preset feature coverage in `/src/presets.ts`.
  - ES2020+ now include `DynamicImport` in whitelist presets.
- Updated module docs in `/docs/MODULES.md`.
  - Replaced outdated “No dynamic import()” limitation with async usage guidance.
- Added regression tests:
  - Parser coverage for `import()` in `/test/ast.test.ts`.
  - Module system coverage in `/test/modules.test.ts` for:
    - module context success
    - async script context success
    - authorization failure
    - cache reuse behavior
    - max depth enforcement
- Added changeset: `/.changeset/slow-pumas-reflect.md`.

## Why this approach
The implementation routes dynamic imports through the same resolver/cache/depth enforcement path as static imports to keep behavior and security policy consistent.

## Validation
- `bun run fmt`
- `bun run lint:fix`
- `bun run typecheck`
- `bun test`
