### PR TITLE
feat: add import.meta support in ES modules

### DIFF
--- a/.changeset/green-humans-admire.md
+++ b/.changeset/green-humans-admire.md
@@ -1,0 +1,5 @@
+---
+"nookjs": minor
+---
+
+Add ES module `import.meta` support with read-only `import.meta.url` and an optional resolver hook for custom `import.meta` fields.

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -455,7 +455,7 @@ const sandbox = createSandbox({
 ## Differences from Native ES Modules
 
 1. **Dynamic import is async-only**: Use `import()` from async contexts (e.g. `await import("./mod.js")`)
-2. **No import.meta**: The `import.meta` object is not available
+2. **Partial import.meta support**: Read-only `import.meta.url` is available (with optional resolver-provided fields)
 3. **Synchronous resolution**: While resolver can be async, module graph is built before execution
 4. **Custom resolution**: No automatic Node.js-style resolution (you control it via resolver)
 5. **No live bindings**: Exports are snapshotted at evaluation time


### PR DESCRIPTION
## Summary

Adds import.meta support for ES module evaluation in NookJS, starting with a read-only import.meta.url and a resolver extension hook for custom metadata fields.

Closes #81.

## What changed

- Added parser support for the import.meta meta-property (MetaProperty AST node + parsing path)
- Added interpreter support for evaluating import.meta during module execution
- Exposes a sandbox-safe, read-only import.meta object to module code
- Derives import.meta.url from the module's canonical path (resolved path for imported modules, options.path for entry modules)
- Added optional ModuleResolver.getImportMeta(...) hook for resolver-provided metadata fields
- Prevented resolver metadata from overriding the derived import.meta.url
- Updated module docs to reflect partial import.meta support
- Added a changeset (minor)

## Tests

- bun run fmt
- bun run lint:fix
- bun run typecheck
- bun test test/modules.test.ts
- bun test

## Notes

- import.meta is available during module evaluation only
- This PR intentionally starts with import.meta.url plus resolver-provided extensions (future fields can be added incrementally)
