### PR TITLE
feat(parser): support TS type-only import/export in strip mode

### DIFF
--- a/.changeset/fuzzy-trees-wave.md
+++ b/.changeset/fuzzy-trees-wave.md
@@ -1,0 +1,5 @@
+---
+"nookjs": minor
+---
+
+Support TypeScript type-only ES module syntax in the strip-only parser, including `import type`, `export type`, and mixed named specifiers like `import { value, type Foo }`.

--- a/docs/AST_PARSER.md
+++ b/docs/AST_PARSER.md
@@ -27,12 +27,12 @@ Type syntax is parsed and discarded so runtime behavior matches plain JavaScript
 - Optional (`?`) and definite assignment (`!`) markers
 - `implements` clauses
 - `type` and `interface` declarations (parsed and dropped)
+- Type-only module syntax (`import type`, `export type`, and mixed `type` specifiers)
 
 Deliberately unsupported:
 
 - TSX/JSX
 - `enum` / `namespace`
-- Type-only imports/exports (`import type`, `export type`)
 - ES module `import` / `export` are parsed, but only allowed during module evaluation (see [MODULES](MODULES.md))
 
 ## Expression Parsing


### PR DESCRIPTION
## Summary
Adds support for TypeScript type-only ES module syntax in the strip-only parser, including `import type`, `export type`, and mixed named specifiers like `import { value, type Foo }`.

## Changes
- strip declaration-level type-only imports/exports from the AST (`import type`, `export type`)
- strip type-only named import/export specifiers while preserving runtime specifiers in mixed declarations
- drop fully type-only module declarations so they do not affect runtime module resolution
- add AST parser regression tests for module and script parsing paths
- add module evaluation regression test proving type-only edges are omitted from runtime resolution
- update `docs/AST_PARSER.md` and add a changeset

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun test` (full suite)
- `bun typecheck`
- `bun test ./test/ast.test.ts ./test/modules.test.ts` (final targeted rerun after parser refactor for typecheck)

Closes #83