### PR TITLE
fix(sandbox): forward sandbox module resolver getImportMeta

### DIFF
--- a/.changeset/fair-goats-jam.md
+++ b/.changeset/fair-goats-jam.md
@@ -1,0 +1,6 @@
+---
+"nookjs": patch
+---
+
+Forward the sandbox module resolver `getImportMeta` hook so `createSandbox({ modules: { resolver } })`
+can customize `import.meta` fields consistently with the interpreter module API.

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -414,6 +414,7 @@ const resolveModules = (modules?: SandboxModules): ModuleOptions | undefined => 
     onError: modules.resolver?.onError
       ? (specifier, importer, error) => modules.resolver?.onError?.(specifier, importer, error)
       : undefined,
+    getImportMeta: modules.resolver?.getImportMeta,
   };
 
   return {


### PR DESCRIPTION
## Summary
- forward `modules.resolver.getImportMeta` from `createSandbox()` into the effective module resolver used by the interpreter
- add a sandbox API regression test proving sandbox-level `getImportMeta` can extend `import.meta`
- verify `import.meta.url` remains runtime-owned and cannot be overridden by resolver output

## Changes
- `src/sandbox.ts`: include `getImportMeta` when composing the sandbox module resolver wrapper
- `test/sandbox-api.test.ts`: add regression coverage for sandbox resolver `getImportMeta` forwarding and URL protection
- `.changeset/fair-goats-jam.md`: patch changeset for the bug fix

## Testing
- `bun test ./test/sandbox-api.test.ts`
- `bun run test`
- `bun run typecheck`
- `bun run fmt`
- `bun run lint:fix`

Closes #95
