### PR TITLE
fix: honor async queue timeouts while waiting for mutex

### DIFF
--- a/.changeset/sharp-ants-hide.md
+++ b/.changeset/sharp-ants-hide.md
@@ -1,0 +1,7 @@
+---
+"nookjs": patch
+---
+
+Honor `timeoutMs`/abort cancellation while async `run()` and `runModule()` calls are waiting in the
+evaluation mutex queue, so queued evaluations abort on wall-clock timeout instead of only after they
+eventually acquire the lock.


### PR DESCRIPTION
## Summary
Fix async sandbox timeout/abort handling when an evaluation is queued behind another async evaluation.

Previously, `timeoutMs` and abort signals were created before dispatch, but cancellation was only checked after acquiring the interpreter evaluation mutex. Under contention, a queued `run()` / `runModule()` call could wait past its timeout and only abort later after the lock was released.

This PR makes mutex acquisition abort-aware so queued evaluations respect wall-clock timeout/abort while waiting.

Fixes #96

## Changes
- make `Interpreter.acquireEvaluationMutex()` accept an optional `AbortSignal`
- race mutex queue waiting against signal abort while queued
- release cancelled queue slots immediately so later queued evaluations are not blocked by a cancelled entry
- pass the evaluation signal into mutex acquisition for both `evaluateAsync()` and `evaluateModuleAsync()`
- add regression tests for queued timeout cancellation in sandbox `run()` and `runModule()`
- add a patch changeset entry

## Tests
- `bun test test/sandbox-api.test.ts`
- `bun run fmt`
- `bun run lint:fix` (1 existing warning remains in `src/sandbox.ts` for `modules.resolver?.getImportMeta` unbound-method)
- `bun run typecheck`
- `bun run test`
