### PR TITLE
fix: preserve resolver descriptors for module externals

### DIFF
--- a/.changeset/swift-cows-clone.md
+++ b/.changeset/swift-cows-clone.md
@@ -1,0 +1,7 @@
+---
+"nookjs": patch
+---
+
+Preserve accessors and branded values when loading resolver-provided module namespace exports and
+`import.meta` extensions by replacing deep cloning at those boundaries with descriptor-preserving
+shallow copies.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -3833,11 +3833,17 @@ export class Interpreter {
     };
 
     if (importMetaExtensions && typeof importMetaExtensions === "object") {
-      for (const [key, value] of Object.entries(importMetaExtensions)) {
+      for (const key of Reflect.ownKeys(importMetaExtensions)) {
         if (key === "url") {
           continue;
         }
-        baseMeta[key] = value;
+
+        const descriptor = Object.getOwnPropertyDescriptor(importMetaExtensions, key);
+        if (!descriptor?.enumerable) {
+          continue;
+        }
+
+        Object.defineProperty(baseMeta, key, descriptor);
       }
     }
 


### PR DESCRIPTION
## Summary
- replace deep cloning of resolver-provided module namespace exports and `getImportMeta()` payloads with descriptor-preserving shallow copies
- preserve getters/accessors and branded nested objects (for example `URL` instances) while still isolating the top-level resolver-owned container
- copy enumerable `import.meta` extension descriptors during merge so getters are not eagerly invoked and `url` remains non-overridable

## Changes
- `src/modules.ts`: remove recursive `deepClone()` usage at resolver boundaries and add `shallowCloneWithDescriptors()` for namespace exports / import-meta payloads
- `src/interpreter.ts`: merge `import.meta` extensions via property descriptors instead of `Object.entries()` assignment
- `test/modules.test.ts`: add regressions for getter-backed namespace exports, getter-backed `import.meta` extensions, and branded `URL` exports
- `.changeset/swift-cows-clone.md`: patch release note

## Testing
- `bun run fmt`
- `bun run lint:fix` (passes with one existing warning in `src/sandbox.ts` about `getImportMeta` unbound-method)
- `bun test`
- `bun run typecheck`

Closes #97
