### PR TITLE
fix(parser): return script sourceType from parseScript

### DIFF
--- a/.changeset/bright-clocks-switch.md
+++ b/.changeset/bright-clocks-switch.md
@@ -1,0 +1,6 @@
+---
+"nookjs": patch
+---
+
+Return the correct `Program.sourceType` from the AST parser helpers: `parseScript()` now emits
+`"script"` and `parseModule()` continues to emit `"module"`.

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -19,7 +19,7 @@ export namespace ESTree {
   export interface Program extends Node {
     readonly type: "Program";
     readonly body: Statement[];
-    readonly sourceType: "module";
+    readonly sourceType: "script" | "module";
   }
 
   export type Statement =
@@ -1534,7 +1534,7 @@ class Parser {
     this.allowTopLevelAwait = allowTopLevelAwait;
   }
 
-  parseProgram(): ESTree.Program {
+  parseProgram(sourceType: ESTree.Program["sourceType"]): ESTree.Program {
     const body: ESTree.Statement[] = [];
     while ((this.currentType as TokenType) !== TOKEN.EOF) {
       if (this.currentType === TOKEN.Punctuator && this.currentValue === ";") {
@@ -1549,7 +1549,7 @@ class Parser {
     return {
       type: "Program",
       body,
-      sourceType: "module",
+      sourceType,
     };
   }
 
@@ -4378,12 +4378,12 @@ class Parser {
 
 export function parseModule(input: string): ESTree.Program {
   const parser = new Parser(stripLeadingHashbang(input), true);
-  return parser.parseProgram();
+  return parser.parseProgram("module");
 }
 
 export function parseScript(input: string): ESTree.Program {
   const parser = new Parser(stripLeadingHashbang(input), false);
-  return parser.parseProgram();
+  return parser.parseProgram("script");
 }
 
 export function parseModuleWithProfile(input: string): {
@@ -4398,7 +4398,7 @@ export function parseModuleWithProfile(input: string): {
   const normalizedInput = stripLeadingHashbang(input);
   const start = now();
   const parser = new Parser(normalizedInput, true, profile);
-  const ast = parser.parseProgram();
+  const ast = parser.parseProgram("module");
   const end = now();
   const total = end - start;
   const parseMs = Math.max(0, total - profile.tokenizeMs);

--- a/test/ast.test.ts
+++ b/test/ast.test.ts
@@ -97,6 +97,16 @@ describe("AST", () => {
         expect(ast.body.length).toBe(1);
         expect(ast.body[0]?.type).toBe("ExpressionStatement");
       });
+
+      it("returns script sourceType for parseScript", () => {
+        const ast = parseScript("1;");
+        expect(ast.sourceType).toBe("script");
+      });
+
+      it("returns module sourceType for parseModule", () => {
+        const ast = parseModule("export const x = 1;");
+        expect(ast.sourceType).toBe("module");
+      });
     });
 
     describe("Control flow", () => {
@@ -459,7 +469,7 @@ describe("AST", () => {
 
         expect(ast).toBeDefined();
         expect(ast.type).toBe("Program");
-        expect(ast.sourceType).toBe("module");
+        expect(ast.sourceType).toBe("script");
         expect(Array.isArray(ast.body)).toBe(true);
       });
 


### PR DESCRIPTION
## Summary

Fix parser `Program.sourceType` metadata for script parsing.

## What Changed

- widened `ESTree.Program.sourceType` to `"script" | "module"`
- updated `Parser.parseProgram()` to accept the source type to emit
- made `parseScript()` return `sourceType: "script"`
- kept `parseModule()` and `parseModuleWithProfile()` returning `sourceType: "module"`
- added regression tests for `parseScript()` / `parseModule()` sourceType values
- updated the `Interpreter.parse()` AST expectation to reflect the corrected script metadata
- added a patch changeset for `nookjs`

## Why

`parseScript()` previously returned a `Program` node tagged as `"module"`, which made AST metadata incorrect for script consumers (including `Interpreter.parse()`, which delegates to `parseScript()`).

## Testing

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`

Closes #98
