### PR TITLE
fix: do not treat all leading type/interface statements as TS-only declarations

### DIFF
--- a/.changeset/metal-masks-study.md
+++ b/.changeset/metal-masks-study.md
@@ -1,0 +1,7 @@
+---
+"nookjs": patch
+---
+
+Tighten TypeScript declaration stripping lookahead so statements starting with `type` or `interface`
+are only skipped when they match actual TS declaration syntax, preserving valid JavaScript labeled
+statements like `type: while (...) {}` and `interface: x = 1`.

--- a/test/ast.test.ts
+++ b/test/ast.test.ts
@@ -284,6 +284,18 @@ describe("AST", () => {
         expect(ast.body[0]?.type).toBe("VariableDeclaration");
       });
 
+      it("parses labeled statements that start with type/interface", () => {
+        const typeLabel = parseFirstStatement("type: while(false){}");
+        expect(typeLabel.type).toBe("LabeledStatement");
+        expect((typeLabel as ESTree.LabeledStatement).label.name).toBe("type");
+        expect((typeLabel as ESTree.LabeledStatement).body.type).toBe("WhileStatement");
+
+        const interfaceLabel = parseFirstStatement("interface: x = 1;");
+        expect(interfaceLabel.type).toBe("LabeledStatement");
+        expect((interfaceLabel as ESTree.LabeledStatement).label.name).toBe("interface");
+        expect((interfaceLabel as ESTree.LabeledStatement).body.type).toBe("ExpressionStatement");
+      });
+
       it("drops type-only imports/exports and strips mixed type specifiers", () => {
         const ast = parseModule(`
           import type { Foo } from "./types";


### PR DESCRIPTION
## Summary
- tighten parser lookahead before entering the TypeScript `type`/`interface` stripping path
- preserve valid JavaScript labeled statements beginning with `type:` or `interface:`
- add AST regression tests and a patch changeset

## Root Cause
`parseStatement()` treated any top-level statement starting with `type` or `interface` as a TypeScript-only declaration and immediately routed it through `parseTypeOnlyStatement()`. For valid JavaScript labels like `type: while(false){}`, that path expects a declaration name after `type` and throws on the colon.

## Changes
- add `isTypeOnlyStatementStart()` lookahead helper using parser snapshot/restore
- only strip `type`/`interface` statements when the upcoming tokens match actual TS declaration syntax
- add regression coverage for `type: while(false){}` and `interface: x = 1;`
- add a patch changeset for the parser compatibility fix

## Validation
- `bun fmt`
- `bun lint:fix` (1 existing warning in `src/sandbox.ts`, no errors)
- `bun test`
- `bun typecheck`

Closes #99
