### PR TITLE
fix: cache ReadOnlyProxy wrappers for stable identity

### DIFF
--- a/.changeset/clean-mice-bathe.md
+++ b/.changeset/clean-mice-bathe.md
@@ -1,0 +1,6 @@
+---
+"nookjs": patch
+---
+
+Cache `ReadOnlyProxy` object proxies and host function wrappers to preserve identity across repeated
+property access and reduce allocations on hot paths.

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -1667,6 +1667,29 @@ describe("Security", () => {
       });
     });
 
+    describe("Wrapper identity stability", () => {
+      it("should return the same proxy for repeated reads of the same nested object", () => {
+        const shared = { value: 42 };
+        const wrapped = ReadOnlyProxy.wrap({ nested: shared }, "obj");
+
+        expect((wrapped as any).nested).toBe((wrapped as any).nested);
+      });
+
+      it("should return the same host function wrapper for repeated method access", () => {
+        const wrapped = ReadOnlyProxy.wrap(
+          {
+            value: 42,
+            method() {
+              return this.value;
+            },
+          },
+          "obj",
+        );
+
+        expect((wrapped as any).method).toBe((wrapped as any).method);
+      });
+    });
+
     describe("Nested object protection", () => {
       it("should recursively protect nested objects", () => {
         const testObj = {


### PR DESCRIPTION
## Summary
- cache ReadOnlyProxy object proxies by effective security options + target object to preserve wrapper identity and reduce repeated allocations
- cache direct host function wrappers and per-target method wrappers while preserving this binding semantics
- invalidate cached method wrappers when the underlying host method reference changes and add regression tests for repeated nested-object/method reads

## Changes
- Added option-scoped WeakMap caches in src/readonly-proxy.ts for object proxies, direct function wrappers, and method wrappers.
- Reused cached method HostFunctionValue instances on repeated property access (obj.method === obj.method).
- Reused cached nested object proxies on repeated reads (obj.nested === obj.nested).
- Added regression coverage in test/security.test.ts.
- Added a patch changeset.

## Validation
- bun fmt
- bun lint:fix (passes with one existing unrelated warning in src/sandbox.ts)
- bun test
- bun typecheck

Fixes #101