### PR TITLE
fix: cache HostFunctionValue static method wrappers

### DIFF
--- a/.changeset/silent-apples-laugh.md
+++ b/.changeset/silent-apples-laugh.md
@@ -1,0 +1,7 @@
+---
+"nookjs": patch
+---
+
+Cache `HostFunctionValue` static method wrappers so repeated reads (for example `Promise.resolve`,
+`Object.keys`, and inherited methods like `Uint8Array.from`) keep stable function identity while
+avoiding unnecessary re-binding/wrapping allocations.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -1724,6 +1724,8 @@ class AsyncGeneratorValue extends BaseGeneratorValue {
  * Allows calling host functions from sandbox code while preventing property access for security
  */
 export class HostFunctionValue {
+  private staticMethodCache: Map<PropertyKey, { original: Function; wrapped: any }> = new Map();
+
   constructor(
     public hostFunc: Function,
     public name: string,
@@ -1775,12 +1777,19 @@ export class HostFunctionValue {
           // For function properties (static methods), bind them to the parent
           // so that `Promise.resolve()` has correct `this` binding
           if (typeof val === "function") {
+            const cached = target.staticMethodCache.get(prop);
+            if (cached && cached.original === val) {
+              return cached.wrapped;
+            }
+
             const bound = val.bind(target.hostFunc);
-            return ReadOnlyProxy.wrap(
+            const wrapped = ReadOnlyProxy.wrap(
               bound,
               `${target.name}.${String(prop)}`,
               target.securityOptions,
             );
+            target.staticMethodCache.set(prop, { original: val, wrapped });
+            return wrapped;
           }
           // Wrap non-function values through ReadOnlyProxy for security
           return ReadOnlyProxy.wrap(val, `${target.name}.${String(prop)}`, target.securityOptions);

--- a/test/host-constructors.test.ts
+++ b/test/host-constructors.test.ts
@@ -467,6 +467,33 @@ describe("Host Constructors", () => {
     });
 
     describe("Static method access on host constructors", () => {
+      it("should return stable wrappers for repeated static method reads", () => {
+        const interpreter = new Interpreter({
+          globals: {
+            Promise,
+            Object,
+            Uint8Array,
+          },
+        });
+
+        const result = interpreter.evaluate(`
+          const promiseResolveA = Promise.resolve;
+          const promiseResolveB = Promise.resolve;
+          const objectKeysA = Object.keys;
+          const objectKeysB = Object.keys;
+          const uint8FromA = Uint8Array.from;
+          const uint8FromB = Uint8Array.from;
+
+          [
+            promiseResolveA === promiseResolveB,
+            objectKeysA === objectKeysB,
+            uint8FromA === uint8FromB,
+          ]
+        `);
+
+        expect(result).toEqual([true, true, true]);
+      });
+
       it("should access Array.isArray()", () => {
         const interpreter = new Interpreter({
           globals: {


### PR DESCRIPTION
## Summary

Cache function-valued static method reads on `HostFunctionValue` so repeated property access returns a stable wrapper instead of re-binding/re-wrapping each time.

This fixes identity inconsistency and allocation overhead for host constructor static methods like `Promise.resolve`, `Object.keys`, and inherited methods like `Uint8Array.from`.

Closes #102

## What Changed

- added a per-`HostFunctionValue` static method cache keyed by property key
- reuse cached wrapped method when the underlying host method reference is unchanged
- automatically refresh cache entry if the underlying method reference changes
- added regression coverage asserting stable identity for repeated reads of:
  - `Promise.resolve`
  - `Object.keys`
  - `Uint8Array.from`
- added a patch changeset for `nookjs`

## Why

Previously, each static method read on a wrapped host function executed `bind()` and then `ReadOnlyProxy.wrap(...)` again. That produced a new callable wrapper each time, so repeated reads were not referentially stable and incurred unnecessary allocations.

## Testing

- `bun fmt`
- `bun lint:fix` (existing warning remains in `src/sandbox.ts` for unbound method reference)
- `bun test`
- `bun typecheck`
