### PR TITLE
fix: avoid mutating iterator result objects in ReadOnlyProxy

### DIFF
--- a/.changeset/bright-sheep-vanish.md
+++ b/.changeset/bright-sheep-vanish.md
@@ -1,0 +1,7 @@
+---
+"nookjs": patch
+---
+
+Avoid mutating host-owned iterator result objects when wrapping yielded values in `ReadOnlyProxy`.
+`wrapIterator` now returns a new iterator result with a wrapped `value`, preventing failures for frozen
+result objects and iterators that reuse result objects across calls.

--- a/src/readonly-proxy.ts
+++ b/src/readonly-proxy.ts
@@ -276,7 +276,10 @@ export class ReadOnlyProxy {
             return async (value?: any) => {
               const result = await (target as AsyncIterator<any>).next(value);
               if (result && typeof result === "object" && "value" in result) {
-                result.value = ReadOnlyProxy.wrap(result.value, `${name}[]`, securityOptions);
+                return {
+                  ...result,
+                  value: ReadOnlyProxy.wrap(result.value, `${name}[]`, securityOptions),
+                };
               }
               return result;
             };
@@ -284,7 +287,10 @@ export class ReadOnlyProxy {
           return (value?: any) => {
             const result = (target as Iterator<any>).next(value);
             if (result && typeof result === "object" && "value" in result) {
-              result.value = ReadOnlyProxy.wrap(result.value, `${name}[]`, securityOptions);
+              return {
+                ...result,
+                value: ReadOnlyProxy.wrap(result.value, `${name}[]`, securityOptions),
+              };
             }
             return result;
           };

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -1850,6 +1850,95 @@ describe("Security", () => {
           result.value.secret = "HACKED";
         }).toThrow("Cannot modify property 'secret' on global 'gen[]' (read-only)");
       });
+
+      it("should not mutate frozen sync iterator result objects", () => {
+        const frozenResult = Object.freeze({
+          value: { secret: "TOP" },
+          done: false,
+        });
+
+        const iterable = {
+          [Symbol.iterator]() {
+            return {
+              next() {
+                return frozenResult;
+              },
+            };
+          },
+        };
+
+        const wrapped = ReadOnlyProxy.wrap(iterable, "iterable");
+        const iterator = (wrapped as any)[Symbol.iterator]();
+        const result = iterator.next();
+
+        expect(result).not.toBe(frozenResult);
+        expect(() => {
+          result.value.secret = "HACKED";
+        }).toThrow("Cannot modify property 'secret' on global 'iterable[]' (read-only)");
+      });
+
+      it("should not corrupt sync iterators that reuse result objects", () => {
+        const sharedResult = {
+          value: { secret: "TOP1" },
+          done: false,
+        };
+        let count = 0;
+
+        const iterable = {
+          [Symbol.iterator]() {
+            return {
+              next() {
+                if (count === 0) {
+                  count += 1;
+                  return sharedResult;
+                }
+                if (count === 1) {
+                  sharedResult.value.secret = "TOP2";
+                  count += 1;
+                  return sharedResult;
+                }
+                return { value: undefined, done: true };
+              },
+            };
+          },
+        };
+
+        const wrapped = ReadOnlyProxy.wrap(iterable, "iterable");
+        const iterator = (wrapped as any)[Symbol.iterator]();
+        iterator.next();
+        let second: any;
+
+        expect(() => {
+          second = iterator.next();
+        }).not.toThrow();
+        expect(second.value.secret).toBe("TOP2");
+      });
+
+      it("should not mutate frozen async iterator result objects", async () => {
+        const frozenResult = Object.freeze({
+          value: { secret: "TOP" },
+          done: false,
+        });
+
+        const asyncIterable = {
+          [Symbol.asyncIterator]() {
+            return {
+              async next() {
+                return frozenResult;
+              },
+            };
+          },
+        };
+
+        const wrapped = ReadOnlyProxy.wrap(asyncIterable, "asyncIterable");
+        const iterator = (wrapped as any)[Symbol.asyncIterator]();
+        const result = await iterator.next();
+
+        expect(result).not.toBe(frozenResult);
+        expect(() => {
+          result.value.secret = "HACKED";
+        }).toThrow("Cannot modify property 'secret' on global 'asyncIterable[]' (read-only)");
+      });
     });
 
     describe("Reflect API bypass prevention", () => {


### PR DESCRIPTION
## Summary
Fix `ReadOnlyProxy.wrapIterator()` so it no longer mutates host-owned iterator result objects when wrapping yielded values.

## Problem
`wrapIterator()` mutated `result.value` in place for both sync and async iterator paths. This breaks iterators that:
- return frozen result objects
- reuse the same result object across multiple `next()` calls

## Changes
- Updated sync iterator wrapping in `src/readonly-proxy.ts` to return a new iterator result object with wrapped `value`
- Updated async iterator wrapping in `src/readonly-proxy.ts` with the same non-mutating behavior
- Added regression tests in `test/security.test.ts` for:
  - frozen sync iterator results
  - reused sync iterator result objects
  - frozen async iterator results
- Added changeset: `.changeset/bright-sheep-vanish.md`

## Validation
- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun typecheck`
- `bun test`
- `bun test test/security.test.ts -t "Iterator wrapping"`

## Notes
`bun lint` reports one existing warning in `src/sandbox.ts` (`typescript-eslint/unbound-method`) unrelated to this change.

Closes #103
