### PR TITLE
[P1] Preserve specifier metadata when different imports resolve to the same module path

### DIFF
--- a/.changeset/calm-poems-trade.md
+++ b/.changeset/calm-poems-trade.md
@@ -1,0 +1,8 @@
+---
+"nookjs": patch
+---
+
+Preserve module introspection metadata when multiple authorized specifiers resolve to the same cached module path.
+
+- Register every successfully resolved specifier before returning an existing cached module record.
+- Add regression coverage for `isModuleCached()`, `getLoadedModuleSpecifiers()`, `getModuleMetadata()`, and `getModuleExportsBySpecifier()` when aliased specifiers share a canonical path.

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -217,6 +217,10 @@ export class ModuleSystem {
       // Cache key is the resolved path (source.path), not the specifier,
       // to ensure cache entries are tied to the specific resolved module.
       if (this.options.cache) {
+        // Preserve all successfully authorized specifiers, even when they
+        // resolve to a module path that is already cached.
+        this.specifierToPath.set(specifier, source.path);
+
         const existingByPath = this.cacheByPath.get(source.path);
         if (existingByPath) {
           // If already initialized, return cached exports
@@ -255,7 +259,6 @@ export class ModuleSystem {
 
       if (this.options.cache) {
         this.cacheByPath.set(source.path, record);
-        this.specifierToPath.set(specifier, source.path);
       }
 
       if (source.type === "namespace") {

--- a/test/modules.test.ts
+++ b/test/modules.test.ts
@@ -3053,6 +3053,42 @@ describe("Module System", () => {
   // ============================================================================
 
   describe("Introspection Edge Cases", () => {
+    test("should preserve introspection metadata for aliased specifiers that share a cached path", async () => {
+      const resolver: ModuleResolver = {
+        resolve(specifier) {
+          if (specifier === "./a" || specifier === "./a.js") {
+            return {
+              type: "source",
+              code: "export const value = 1;",
+              path: "/modules/a.js",
+            };
+          }
+          return null;
+        },
+      };
+
+      const interpreter = new Interpreter({
+        modules: { enabled: true, resolver, cache: true },
+      });
+
+      const result = await interpreter.evaluateModuleAsync(
+        'import { value as first } from "./a"; import { value as second } from "./a.js"; export const sum = first + second;',
+        { path: "main.js" },
+      );
+
+      expect(result.sum).toBe(2);
+      expect(interpreter.getModuleCacheSize()).toBe(1);
+      expect(interpreter.getLoadedModulePaths()).toEqual(["/modules/a.js"]);
+      expect(interpreter.isModuleCached("./a")).toBe(true);
+      expect(interpreter.isModuleCached("./a.js")).toBe(true);
+      expect(interpreter.getLoadedModuleSpecifiers()).toEqual(
+        expect.arrayContaining(["./a", "./a.js"]),
+      );
+      expect(interpreter.getModuleMetadata("./a")?.path).toBe("/modules/a.js");
+      expect(interpreter.getModuleMetadata("./a.js")?.path).toBe("/modules/a.js");
+      expect(interpreter.getModuleExportsBySpecifier("./a.js")?.value).toBe(1);
+    });
+
     test("should return undefined metadata for non-existent module", async () => {
       const resolver: ModuleResolver = {
         resolve() {


### PR DESCRIPTION
## Summary
- register every successfully resolved specifier before returning an existing cached module record
- preserve path-based module caching while keeping specifier-based introspection accurate for aliased imports
- add a regression test covering aliased specifiers that resolve to the same canonical path
- include a patch changeset for the fix

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`

Closes #118