### PR TITLE
docs: align README limitations with current parser and module support

### DIFF
--- a/.changeset/tiny-schools-grin.md
+++ b/.changeset/tiny-schools-grin.md
@@ -1,0 +1,9 @@
+---
+"nookjs": patch
+---
+
+Align the top-level README limitation notes with the parser and module features that already ship.
+
+- Document leading hashbang stripping and type-only import/export erasure as supported behavior.
+- Document dynamic `import()`, partial `import.meta`, and live bindings as supported module features.
+- Reframe the remaining module caveats around the still-approximate parts of native ESM semantics.

--- a/README.md
+++ b/README.md
@@ -574,15 +574,21 @@ With `"strict-js"`:
 ### Syntax/feature scope
 
 - Parser targets interpreter-supported syntax, not arbitrary JS/TS grammar.
-- Hashbang (`#!`) is not stripped by the parser.
-- TypeScript support is strip-only and excludes TSX/JSX, `enum`, `namespace`, and type-only import/export.
+- Leading hashbang (`#!`) lines are stripped in script/module entry parsing.
+- TypeScript support is strip-only: it handles type annotations and type-only import/export erasure, but still excludes TSX/JSX, `enum`, and `namespace`.
 - Some constructs have intentionally narrower behavior (for example, spread/destructuring/loop gotchas in feature docs).
 
-### Module system gaps vs native ESM
+### Module system: supported today vs native ESM gaps
 
-- No dynamic `import()`.
-- No `import.meta`.
-- No live bindings; exports are snapshot-based.
+Supported today:
+
+- Async `import()` works during module evaluation and async script execution.
+- Read-only `import.meta.url` is available, and resolvers can extend `import.meta` with additional fields.
+- Named imports/re-exports use live bindings across the module graph.
+
+Still intentionally approximate:
+
+- Full native ESM TDZ/instantiation timing is not guaranteed.
 - Module resolution is custom/resolver-driven (no automatic Node resolution).
 - Module system is opt-in and disabled unless `modules` config is provided.
 


### PR DESCRIPTION
## Summary
- update the top-level README limitations to match the parser and module behavior already covered by implementation/tests
- add a release-note style split between what the module system supports today and what remains intentionally approximate vs native ESM
- add the required patch changeset for the documentation contract update

## Changes
- document leading hashbang stripping in script/module entry parsing
- document strip-only TypeScript support as including type-only import/export erasure, while keeping TSX/JSX, enum, and namespace listed as unsupported
- document async `import()`, read-only `import.meta.url` with resolver extensions, and live bindings as supported behavior
- keep the remaining native ESM caveats focused on TDZ/instantiation timing, custom resolution, and opt-in module configuration

## Validation
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`

Fixes #119