### PR TITLE
fix: honor thisArg for Map.prototype.forEach and Set.prototype.forEach

### DIFF
--- a/.changeset/swift-sheep-pull.md
+++ b/.changeset/swift-sheep-pull.md
@@ -1,0 +1,6 @@
+---
+"nookjs": patch
+---
+
+Honor `thisArg` when sandbox callbacks are passed to delegated `Map.prototype.forEach`
+and `Set.prototype.forEach`.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -5933,13 +5933,15 @@ export class Interpreter {
       if (arg instanceof FunctionValue) {
         // Wrap sandbox function as a callable native function
         if (isAsync || arg.isAsync) {
-          wrappedArgs[i] = async (...hostArgs: any[]) => {
-            return await this.executeSandboxFunctionAsync(arg, hostArgs, undefined);
-          };
+          wrappedArgs[i] = ((interpreter: Interpreter, callback: FunctionValue) =>
+            async function (this: any, ...hostArgs: any[]) {
+              return await interpreter.executeSandboxFunctionAsync(callback, hostArgs, this);
+            })(this, arg);
         } else {
-          wrappedArgs[i] = (...hostArgs: any[]) => {
-            return this.executeSandboxFunction(arg, hostArgs, undefined);
-          };
+          wrappedArgs[i] = ((interpreter: Interpreter, callback: FunctionValue) =>
+            function (this: any, ...hostArgs: any[]) {
+              return interpreter.executeSandboxFunction(callback, hostArgs, this);
+            })(this, arg);
         }
       } else {
         // Unwrap proxied TypedArrays/ArrayBuffers for native method compatibility

--- a/test/collections.test.ts
+++ b/test/collections.test.ts
@@ -188,6 +188,19 @@ describe("Collections", () => {
         expect(result).toEqual(["a1", "b2"]);
       });
 
+      it("should honor thisArg in forEach callbacks", () => {
+        const interpreter = new Interpreter(ES2015);
+        const result = interpreter.evaluate(`
+          const ctx = { sum: 0 };
+          const map = new Map([[1, 2]]);
+          map.forEach(function (value, key) {
+            this.sum += value + key;
+          }, ctx);
+          ctx.sum;
+        `);
+        expect(result).toBe(3);
+      });
+
       it("should expose keys, values, and entries iterators", () => {
         const interpreter = new Interpreter(ES2015);
         const result = interpreter.evaluate(`
@@ -337,6 +350,19 @@ describe("Collections", () => {
           values;
         `);
         expect(result).toEqual([2, 4, 6]);
+      });
+
+      it("should honor thisArg in forEach callbacks", () => {
+        const interpreter = new Interpreter(ES2015);
+        const result = interpreter.evaluate(`
+          const ctx = { total: 0 };
+          const set = new Set([1, 2, 3]);
+          set.forEach(function (value, key) {
+            this.total += value + key;
+          }, ctx);
+          ctx.total;
+        `);
+        expect(result).toBe(12);
       });
 
       it("should expose values and entries iterators", () => {


### PR DESCRIPTION
## Summary
- preserve the host-supplied callback receiver when sandbox functions are adapted for delegated native method calls
- fix delegated `Map.prototype.forEach` and `Set.prototype.forEach` so sandbox callbacks honor the optional `thisArg`
- add regression tests for both collection methods and include a patch changeset

## Testing
- `bun lint:fix`
- `bun typecheck`
- `bun test`

Fixes #146
