### PR TITLE
Fix callback thisArg handling for array helpers

### DIFF
--- a/.changeset/fair-planets-work.md
+++ b/.changeset/fair-planets-work.md
@@ -1,0 +1,7 @@
+---
+"nookjs": patch
+---
+
+Honor `thisArg` for callback-based array helpers, including `map`, `filter`, `every`, `some`,
+`forEach`, `find`, `findIndex`, `findLast`, `findLastIndex`, and `flatMap`, while preserving
+lexical `this` for arrow callbacks.

--- a/docs/ARRAY_METHODS.md
+++ b/docs/ARRAY_METHODS.md
@@ -88,6 +88,13 @@ for (const [index, value] of [1, 2].entries()) {
 }
 ```
 
+### Callback `thisArg`
+
+Callback-based methods that accept an optional `thisArg`, including `map()`, `filter()`,
+`every()`, `some()`, `forEach()`, `find()`, `findIndex()`, `findLast()`, `findLastIndex()`,
+and `flatMap()`, honor that binding for classic functions. Arrow functions still keep lexical
+`this`, matching native JavaScript.
+
 ### findLast / findLastIndex Behavior
 
 These methods iterate from the end of the array:

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -8545,7 +8545,7 @@ export class Interpreter {
       // Higher-order methods - these need special handling to evaluate sandbox functions
       case "map":
         return this.createHostFunction(
-          (callback: FunctionValue | Function) => {
+          (callback: FunctionValue | Function, thisArg?: any) => {
             const length = arr.length;
             const result: any[] = [];
             result.length = length;
@@ -8554,7 +8554,7 @@ export class Interpreter {
                 continue;
               }
               // Call the callback with (element, index, array)
-              const value = this.callCallback(callback, undefined, [arr[i], i, arr]);
+              const value = this.callCallback(callback, thisArg, [arr[i], i, arr]);
               result[i] = value;
             }
             return result;
@@ -8567,14 +8567,14 @@ export class Interpreter {
 
       case "filter":
         return this.createHostFunction(
-          (callback: FunctionValue | Function) => {
+          (callback: FunctionValue | Function, thisArg?: any) => {
             const length = arr.length;
             const result: any[] = [];
             for (let i = 0; i < length; i++) {
               if (!hasIndex(i)) {
                 continue;
               }
-              const shouldInclude = this.callCallback(callback, undefined, [arr[i], i, arr]);
+              const shouldInclude = this.callCallback(callback, thisArg, [arr[i], i, arr]);
               if (shouldInclude) {
                 result.push(arr[i]);
               }
@@ -8621,9 +8621,9 @@ export class Interpreter {
 
       case "find":
         return this.createHostFunction(
-          (callback: FunctionValue | Function) => {
+          (callback: FunctionValue | Function, thisArg?: any) => {
             for (let i = 0; i < arr.length; i++) {
-              const matches = this.callCallback(callback, undefined, [arr[i], i, arr]);
+              const matches = this.callCallback(callback, thisArg, [arr[i], i, arr]);
               if (matches) {
                 return arr[i];
               }
@@ -8638,9 +8638,9 @@ export class Interpreter {
 
       case "findIndex":
         return this.createHostFunction(
-          (callback: FunctionValue | Function) => {
+          (callback: FunctionValue | Function, thisArg?: any) => {
             for (let i = 0; i < arr.length; i++) {
-              const matches = this.callCallback(callback, undefined, [arr[i], i, arr]);
+              const matches = this.callCallback(callback, thisArg, [arr[i], i, arr]);
               if (matches) {
                 return i;
               }
@@ -8655,13 +8655,13 @@ export class Interpreter {
 
       case "every":
         return this.createHostFunction(
-          (callback: FunctionValue | Function) => {
+          (callback: FunctionValue | Function, thisArg?: any) => {
             const length = arr.length;
             for (let i = 0; i < length; i++) {
               if (!hasIndex(i)) {
                 continue;
               }
-              const result = this.callCallback(callback, undefined, [arr[i], i, arr]);
+              const result = this.callCallback(callback, thisArg, [arr[i], i, arr]);
               if (!result) {
                 return false;
               }
@@ -8676,13 +8676,13 @@ export class Interpreter {
 
       case "some":
         return this.createHostFunction(
-          (callback: FunctionValue | Function) => {
+          (callback: FunctionValue | Function, thisArg?: any) => {
             const length = arr.length;
             for (let i = 0; i < length; i++) {
               if (!hasIndex(i)) {
                 continue;
               }
-              const result = this.callCallback(callback, undefined, [arr[i], i, arr]);
+              const result = this.callCallback(callback, thisArg, [arr[i], i, arr]);
               if (result) {
                 return true;
               }
@@ -8697,13 +8697,13 @@ export class Interpreter {
 
       case "forEach":
         return this.createHostFunction(
-          (callback: FunctionValue | Function) => {
+          (callback: FunctionValue | Function, thisArg?: any) => {
             const length = arr.length;
             for (let i = 0; i < length; i++) {
               if (!hasIndex(i)) {
                 continue;
               }
-              this.callCallback(callback, undefined, [arr[i], i, arr]);
+              this.callCallback(callback, thisArg, [arr[i], i, arr]);
             }
             return undefined;
           },
@@ -8735,14 +8735,14 @@ export class Interpreter {
 
       case "flatMap":
         return this.createHostFunction(
-          (callback: FunctionValue | Function) => {
+          (callback: FunctionValue | Function, thisArg?: any) => {
             const length = arr.length;
             const result: any[] = [];
             for (let i = 0; i < length; i++) {
               if (!hasIndex(i)) {
                 continue;
               }
-              const mapped = this.callCallback(callback, undefined, [arr[i], i, arr]);
+              const mapped = this.callCallback(callback, thisArg, [arr[i], i, arr]);
               if (Array.isArray(mapped)) {
                 for (let j = 0; j < mapped.length; j++) {
                   if (j in mapped) {
@@ -8766,9 +8766,9 @@ export class Interpreter {
 
       case "findLast":
         return this.createHostFunction(
-          (callback: FunctionValue | Function) => {
+          (callback: FunctionValue | Function, thisArg?: any) => {
             for (let i = arr.length - 1; i >= 0; i--) {
-              const matches = this.callCallback(callback, undefined, [arr[i], i, arr]);
+              const matches = this.callCallback(callback, thisArg, [arr[i], i, arr]);
               if (matches) {
                 return arr[i];
               }
@@ -8783,9 +8783,9 @@ export class Interpreter {
 
       case "findLastIndex":
         return this.createHostFunction(
-          (callback: FunctionValue | Function) => {
+          (callback: FunctionValue | Function, thisArg?: any) => {
             for (let i = arr.length - 1; i >= 0; i--) {
-              const matches = this.callCallback(callback, undefined, [arr[i], i, arr]);
+              const matches = this.callCallback(callback, thisArg, [arr[i], i, arr]);
               if (matches) {
                 return i;
               }
@@ -9172,45 +9172,12 @@ export class Interpreter {
 
   private callCallback(callback: FunctionValue | Function, thisValue: any, args: any[]): any {
     if (callback instanceof FunctionValue) {
-      return this.callSandboxFunction(callback, thisValue, args);
+      return this.executeSandboxFunction(callback, args, thisValue);
     }
     if (typeof callback === "function") {
       return callback.apply(thisValue, args);
     }
     throw new InterpreterError("Callback must be a function");
-  }
-
-  /**
-   * Helper to call a sandbox function (used by array methods)
-   */
-  private callSandboxFunction(func: FunctionValue, thisValue: any, args: any[]): any {
-    // Save and restore environment
-    const previousEnvironment = this.environment;
-    this.environment = new Environment(func.closure, thisValue, true);
-
-    try {
-      // Bind parameters
-      for (let i = 0; i < func.params.length && i < args.length; i++) {
-        if (func.destructuredParams.has(i)) {
-          const pattern = func.destructuredParams.get(i)!;
-          this.destructurePattern(pattern, args[i], true, "let");
-        } else {
-          this.environment.declare(func.params[i]!, args[i], "let");
-        }
-      }
-
-      // Execute function body
-      const result = this.evaluateNode(func.body);
-
-      // Unwrap return value
-      if (isControlFlowKind(result, "return")) {
-        return result.value;
-      }
-
-      return undefined;
-    } finally {
-      this.environment = previousEnvironment;
-    }
   }
 
   private evaluateArrayExpression(node: ESTree.ArrayExpression): any {

--- a/test/arrays.test.ts
+++ b/test/arrays.test.ts
@@ -2046,6 +2046,133 @@ describe("Arrays", () => {
       });
     });
 
+    describe("callback thisArg", () => {
+      const callbackThisArgCases = [
+        {
+          methodName: "map",
+          expression: `
+            const ctx = { multiplier: 3 };
+            [1, 2].map(function (value) {
+              return value * this.multiplier;
+            }, ctx);
+          `,
+          expected: [3, 6],
+        },
+        {
+          methodName: "filter",
+          expression: `
+            const ctx = { min: 1 };
+            [1, 2, 3].filter(function (value) {
+              return value > this.min;
+            }, ctx);
+          `,
+          expected: [2, 3],
+        },
+        {
+          methodName: "every",
+          expression: `
+            const ctx = { min: 0 };
+            [1, 2, 3].every(function (value) {
+              return value > this.min;
+            }, ctx);
+          `,
+          expected: true,
+        },
+        {
+          methodName: "some",
+          expression: `
+            const ctx = { min: 2 };
+            [1, 2, 3].some(function (value) {
+              return value > this.min;
+            }, ctx);
+          `,
+          expected: true,
+        },
+        {
+          methodName: "forEach",
+          expression: `
+            const ctx = { total: 0 };
+            [1, 2, 3].forEach(function (value) {
+              this.total += value;
+            }, ctx);
+            ctx.total;
+          `,
+          expected: 6,
+        },
+        {
+          methodName: "find",
+          expression: `
+            const ctx = { min: 2 };
+            [1, 2, 3].find(function (value) {
+              return value > this.min;
+            }, ctx);
+          `,
+          expected: 3,
+        },
+        {
+          methodName: "findIndex",
+          expression: `
+            const ctx = { min: 1 };
+            [1, 2, 3].findIndex(function (value) {
+              return value > this.min;
+            }, ctx);
+          `,
+          expected: 1,
+        },
+        {
+          methodName: "flatMap",
+          expression: `
+            const ctx = { multiplier: 3 };
+            [1, 2].flatMap(function (value) {
+              return [value, value * this.multiplier];
+            }, ctx);
+          `,
+          expected: [1, 3, 2, 6],
+        },
+        {
+          methodName: "findLast",
+          expression: `
+            const ctx = { max: 3 };
+            [1, 2, 3, 4].findLast(function (value) {
+              return value < this.max;
+            }, ctx);
+          `,
+          expected: 2,
+        },
+        {
+          methodName: "findLastIndex",
+          expression: `
+            const ctx = { max: 3 };
+            [1, 2, 3, 4].findLastIndex(function (value) {
+              return value < this.max;
+            }, ctx);
+          `,
+          expected: 1,
+        },
+      ];
+
+      for (const { methodName, expression, expected } of callbackThisArgCases) {
+        it(`should honor thisArg for ${methodName}`, () => {
+          expect(interpreter.evaluate(expression)).toEqual(expected);
+        });
+      }
+
+      it("should preserve lexical this for arrow callbacks when thisArg is provided", () => {
+        expect(
+          interpreter.evaluate(`
+            const tracker = {
+              multiplier: 10,
+              mapValues() {
+                const ctx = { multiplier: 99 };
+                return [1, 2].map((value) => value * this.multiplier, ctx);
+              }
+            };
+            tracker.mapValues();
+          `),
+        ).toEqual([10, 20]);
+      });
+    });
+
     describe("Array.prototype.toReversed", () => {
       it("should return reversed array without modifying original", () => {
         expect(


### PR DESCRIPTION
## Summary
- honor the optional `thisArg` parameter for callback-based array helpers (`map`, `filter`, `every`, `some`, `forEach`, `find`, `findIndex`, `findLast`, `findLastIndex`, and `flatMap`)
- route sandbox callbacks through the standard sandbox function execution path so classic functions receive the provided binding while arrow functions keep lexical `this`
- add regression coverage for each affected helper, document the behavior, and include a patch changeset

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`

Closes #142