### PR TITLE
fix: snapshot initial length for callback-based find helpers

### DIFF
--- a/.changeset/tiny-rockets-arrive.md
+++ b/.changeset/tiny-rockets-arrive.md
@@ -1,0 +1,7 @@
+---
+"nookjs": patch
+---
+
+Snapshot the initial length for `Array.prototype.find` and `Array.prototype.findIndex` so
+callback-based iteration ignores elements appended during traversal, and add regression coverage
+for mutation during `map`, `filter`, `forEach`, `find`, and `findIndex`.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -8622,7 +8622,8 @@ export class Interpreter {
       case "find":
         return this.createHostFunction(
           (callback: FunctionValue | Function, thisArg?: any) => {
-            for (let i = 0; i < arr.length; i++) {
+            const length = arr.length;
+            for (let i = 0; i < length; i++) {
               const matches = this.callCallback(callback, thisArg, [arr[i], i, arr]);
               if (matches) {
                 return arr[i];
@@ -8639,7 +8640,8 @@ export class Interpreter {
       case "findIndex":
         return this.createHostFunction(
           (callback: FunctionValue | Function, thisArg?: any) => {
-            for (let i = 0; i < arr.length; i++) {
+            const length = arr.length;
+            for (let i = 0; i < length; i++) {
               const matches = this.callCallback(callback, thisArg, [arr[i], i, arr]);
               if (matches) {
                 return i;

--- a/test/arrays.test.ts
+++ b/test/arrays.test.ts
@@ -1035,6 +1035,24 @@ describe("Arrays", () => {
                   `);
           expect(result).toEqual([3, false, 2, 6]);
         });
+
+        it("should ignore elements appended during iteration", () => {
+          const interpreter = new Interpreter();
+          const result = interpreter.evaluate(`
+                    const arr = [1, 2];
+                    const mapped = arr.map((value, index, source) => {
+                      if (index === 0) {
+                        source.push(3);
+                      }
+                      return value * 2;
+                    });
+                    [mapped, arr]
+                  `);
+          expect(result).toEqual([
+            [2, 4],
+            [1, 2, 3],
+          ]);
+        });
       });
 
       describe("filter", () => {
@@ -1096,6 +1114,24 @@ describe("Arrays", () => {
                     arr.filter(item => item.active)
                   `);
           expect(result).toEqual([{ active: true }, { active: true }]);
+        });
+
+        it("should ignore elements appended during iteration", () => {
+          const interpreter = new Interpreter();
+          const result = interpreter.evaluate(`
+                    const arr = [1, 2];
+                    const filtered = arr.filter((value, index, source) => {
+                      if (index === 0) {
+                        source.push(3);
+                      }
+                      return true;
+                    });
+                    [filtered, arr]
+                  `);
+          expect(result).toEqual([
+            [1, 2],
+            [1, 2, 3],
+          ]);
         });
       });
 
@@ -1475,6 +1511,22 @@ describe("Arrays", () => {
                   `);
           expect(result).toBe(0);
         });
+
+        it("should ignore elements appended during iteration", () => {
+          const interpreter = new Interpreter();
+          const result = interpreter.evaluate(`
+                    const arr = [1, 2];
+                    let calls = 0;
+                    arr.forEach((value, index, source) => {
+                      calls++;
+                      if (index === 0) {
+                        source.push(3);
+                      }
+                    });
+                    [calls, arr]
+                  `);
+          expect(result).toEqual([2, [1, 2, 3]]);
+        });
       });
 
       describe("splice", () => {
@@ -1671,6 +1723,23 @@ describe("Arrays", () => {
                   `);
           expect(result).toEqual({ id: 2, name: "Bob" });
         });
+
+        it("should ignore elements appended during iteration", () => {
+          const interpreter = new Interpreter();
+          const result = interpreter.evaluate(`
+                    const arr = [1, 2];
+                    let calls = 0;
+                    const found = arr.find((value, index, source) => {
+                      calls++;
+                      if (index === 0) {
+                        source.push(3);
+                      }
+                      return value === 3;
+                    });
+                    [found, calls, arr]
+                  `);
+          expect(result).toEqual([undefined, 2, [1, 2, 3]]);
+        });
       });
 
       describe("findIndex", () => {
@@ -1690,6 +1759,23 @@ describe("Arrays", () => {
                     arr.findIndex(x => x > 10)
                   `);
           expect(result).toBe(-1);
+        });
+
+        it("should ignore elements appended during iteration", () => {
+          const interpreter = new Interpreter();
+          const result = interpreter.evaluate(`
+                    const arr = [1, 2];
+                    let calls = 0;
+                    const foundIndex = arr.findIndex((value, index, source) => {
+                      calls++;
+                      if (index === 0) {
+                        source.push(3);
+                      }
+                      return value === 3;
+                    });
+                    [foundIndex, calls, arr]
+                  `);
+          expect(result).toEqual([-1, 2, [1, 2, 3]]);
         });
       });
     });


### PR DESCRIPTION
Fixes samlaycock/nookjs#141\n\n## Summary\n- snapshot the initial array length in `Array.prototype.find` and `findIndex` before callback iteration\n- add mutation-during-iteration regression coverage for `map`, `filter`, `forEach`, `find`, and `findIndex`\n- add a patch changeset for the array helper behavior fix\n\n## Testing\n- `bun fmt`\n- `bun lint:fix`\n- `bun test`\n- `bun typecheck`