### PR TITLE
fix: cache primitive method wrappers

### DIFF
--- a/.changeset/tall-melons-divide.md
+++ b/.changeset/tall-melons-divide.md
@@ -1,3 +1,4 @@
+---
 "nookjs": patch
 ---
 

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -144,13 +144,22 @@ interface CachedHostFunctionWrapper {
   readonly wrapper: HostFunctionValue;
 }
 
+type PrimitiveMethodCacheKey = string | number | boolean | bigint | symbol;
+
+type PrimitiveMethodCache<K extends PrimitiveMethodCacheKey> = Map<
+  K,
+  Map<string, CachedHostFunctionWrapper>
+>;
+
 interface PrimitiveMethodCaches {
-  readonly string: Map<string, Map<string, CachedHostFunctionWrapper>>;
-  readonly number: Map<number, Map<string, CachedHostFunctionWrapper>>;
-  readonly boolean: Map<boolean, Map<string, CachedHostFunctionWrapper>>;
-  readonly bigint: Map<bigint, Map<string, CachedHostFunctionWrapper>>;
-  readonly symbol: Map<symbol, Map<string, CachedHostFunctionWrapper>>;
+  readonly string: PrimitiveMethodCache<string>;
+  readonly number: PrimitiveMethodCache<number>;
+  readonly boolean: PrimitiveMethodCache<boolean>;
+  readonly bigint: PrimitiveMethodCache<bigint>;
+  readonly symbol: PrimitiveMethodCache<symbol>;
 }
+
+const MAX_PRIMITIVE_METHOD_CACHE_ENTRIES = 256;
 
 /**
  * Represents a class defined in the sandbox (interpreted JavaScript)
@@ -8558,47 +8567,44 @@ export class Interpreter {
   private getPrimitiveMethodEntries(
     value: string | number | boolean | bigint | symbol,
   ): Map<string, CachedHostFunctionWrapper> {
-    let cacheByProperty: Map<string, CachedHostFunctionWrapper> | undefined;
-
     switch (typeof value) {
       case "string":
-        cacheByProperty = this.primitiveMethodCache.string.get(value);
-        if (!cacheByProperty) {
-          cacheByProperty = new Map();
-          this.primitiveMethodCache.string.set(value, cacheByProperty);
-        }
-        return cacheByProperty;
+        return this.getOrCreatePrimitiveMethodEntries(this.primitiveMethodCache.string, value);
       case "number":
-        cacheByProperty = this.primitiveMethodCache.number.get(value);
-        if (!cacheByProperty) {
-          cacheByProperty = new Map();
-          this.primitiveMethodCache.number.set(value, cacheByProperty);
-        }
-        return cacheByProperty;
+        return this.getOrCreatePrimitiveMethodEntries(this.primitiveMethodCache.number, value);
       case "boolean":
-        cacheByProperty = this.primitiveMethodCache.boolean.get(value);
-        if (!cacheByProperty) {
-          cacheByProperty = new Map();
-          this.primitiveMethodCache.boolean.set(value, cacheByProperty);
-        }
-        return cacheByProperty;
+        return this.getOrCreatePrimitiveMethodEntries(this.primitiveMethodCache.boolean, value);
       case "bigint":
-        cacheByProperty = this.primitiveMethodCache.bigint.get(value);
-        if (!cacheByProperty) {
-          cacheByProperty = new Map();
-          this.primitiveMethodCache.bigint.set(value, cacheByProperty);
-        }
-        return cacheByProperty;
+        return this.getOrCreatePrimitiveMethodEntries(this.primitiveMethodCache.bigint, value);
       case "symbol":
-        cacheByProperty = this.primitiveMethodCache.symbol.get(value);
-        if (!cacheByProperty) {
-          cacheByProperty = new Map();
-          this.primitiveMethodCache.symbol.set(value, cacheByProperty);
-        }
-        return cacheByProperty;
+        return this.getOrCreatePrimitiveMethodEntries(this.primitiveMethodCache.symbol, value);
       default:
         throw new InterpreterError("Primitive method cache requires a primitive value");
     }
+  }
+
+  private getOrCreatePrimitiveMethodEntries<K extends PrimitiveMethodCacheKey>(
+    cache: PrimitiveMethodCache<K>,
+    value: K,
+  ): Map<string, CachedHostFunctionWrapper> {
+    const existingEntries = cache.get(value);
+    if (existingEntries) {
+      // Refresh insertion order so eviction keeps the most recently used primitive caches.
+      cache.delete(value);
+      cache.set(value, existingEntries);
+      return existingEntries;
+    }
+
+    if (cache.size >= MAX_PRIMITIVE_METHOD_CACHE_ENTRIES) {
+      const oldestKey = cache.keys().next().value;
+      if (oldestKey !== undefined) {
+        cache.delete(oldestKey);
+      }
+    }
+
+    const entries = new Map<string, CachedHostFunctionWrapper>();
+    cache.set(value, entries);
+    return entries;
   }
 
   private buildArrayMethod(arr: any[], methodName: string): HostFunctionValue | null {

--- a/test/native-method-delegation.test.ts
+++ b/test/native-method-delegation.test.ts
@@ -11,6 +11,16 @@ describe("Native Method Delegation", () => {
         expect(result).toBe(true);
       });
 
+      it("should bound primitive string method cache growth", () => {
+        const interpreter = new Interpreter();
+
+        for (let index = 0; index <= 300; index += 1) {
+          interpreter.evaluate(`"value-${index}".trim === "value-${index}".trim`);
+        }
+
+        expect((interpreter as any).primitiveMethodCache.string.size).toBeLessThanOrEqual(256);
+      });
+
       it("should support replaceAll", () => {
         const interpreter = new Interpreter();
         const result = interpreter.evaluate(`"aabbcc".replaceAll("b", "x")`);


### PR DESCRIPTION
## Summary
- cache primitive method wrappers per interpreter so repeated reads return a stable `HostFunctionValue` instead of allocating a fresh wrapper
- reuse that cache for explicit string helpers like `trim` and delegated primitive prototype methods like `toFixed`
- add regression tests for repeated method identity reads and include a patch changeset

## Testing
- bun fmt
- bun lint:fix
- bun typecheck
- bun test

Fixes #140