### PR TITLE
fix: align String.prototype.split(null) with native coercion semantics

### DIFF
--- a/.changeset/issue-161-split-null.md
+++ b/.changeset/issue-161-split-null.md
@@ -1,0 +1,6 @@
+---
+"nookjs": patch
+---
+
+Align `String.prototype.split(null)` with native JavaScript semantics by coercing `null` to the
+string `"null"` while continuing to treat `undefined` as an omitted separator.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -9446,9 +9446,12 @@ export class Interpreter {
       // Transformation methods
       case "split":
         return this.createHostFunction(
-          (separator?: string | null, limit?: number) => {
-            if (separator === null || separator === undefined) {
+          (separator?: string | RegExp | null, limit?: number) => {
+            if (separator === undefined) {
               return [str];
+            }
+            if (separator === null) {
+              return str.split("null", limit);
             }
             return str.split(separator, limit);
           },

--- a/test/strings.test.ts
+++ b/test/strings.test.ts
@@ -826,6 +826,12 @@ describe("Strings", () => {
           expect(result).toEqual(["aundefinedb"]);
         });
 
+        it("should coerce null separator to the string null", () => {
+          const interpreter = new Interpreter();
+          const result = interpreter.evaluate(`"nullxnull".split(null)`);
+          expect(result).toEqual(["", "x", ""]);
+        });
+
         it("should split by space", () => {
           const interpreter = new Interpreter();
           const result = interpreter.evaluate(`


### PR DESCRIPTION
## Summary
- add a regression test for `String.prototype.split(null)` in the string method suite
- treat only `undefined` as an omitted separator in the string split wrapper
- coerce `null` to the string `"null"` before delegating to the host implementation
- include a patch changeset for the compatibility fix

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`

Closes #161
