### PR TITLE
fix: reject unsupported enum and namespace declarations during parsing

### DIFF
--- a/.changeset/issue-162-reject-enum-namespace.md
+++ b/.changeset/issue-162-reject-enum-namespace.md
@@ -1,0 +1,7 @@
+---
+"nookjs": patch
+---
+
+Reject TypeScript `enum` and `namespace` declaration syntax during parsing so `parse()` and
+`evaluate()` fail fast with a `ParseError` instead of degrading into confusing runtime identifier
+errors.

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -1708,6 +1708,13 @@ class Parser {
         this.parseTypeOnlyStatement(value);
         return null;
       }
+
+      const unsupportedTypeScriptDeclaration = this.getUnsupportedTypeScriptDeclarationKind();
+      if (unsupportedTypeScriptDeclaration !== null) {
+        throw new ParseError(
+          `TypeScript '${unsupportedTypeScriptDeclaration}' declarations are not supported`,
+        );
+      }
     }
     let result: ESTree.Statement | null = null;
     if (type === TOKEN.Keyword) {
@@ -1790,6 +1797,40 @@ class Parser {
 
   private parseStatementOrEmpty(): ESTree.Statement {
     return this.parseStatement() ?? { type: "EmptyStatement" };
+  }
+
+  private getUnsupportedTypeScriptDeclarationKind(): "enum" | "namespace" | null {
+    if (
+      (this.currentType !== TOKEN.Identifier && this.currentType !== TOKEN.Keyword) ||
+      (this.currentValue !== "enum" && this.currentValue !== "namespace")
+    ) {
+      return null;
+    }
+
+    const kind = this.currentValue as "enum" | "namespace";
+    const snapshot = this.snapshot();
+
+    try {
+      this.next();
+      this.parseIdentifier();
+
+      if (kind === "namespace") {
+        while (this.consumePunctuator(".")) {
+          this.parseIdentifier();
+        }
+      }
+
+      const currentType = this.currentType as TokenType;
+      const currentValue = this.currentValue as string;
+      return currentType === TOKEN.Punctuator && currentValue === "{" ? kind : null;
+    } catch (error) {
+      if (error instanceof ParseError) {
+        return null;
+      }
+      throw error;
+    } finally {
+      this.restore(snapshot);
+    }
   }
 
   private isTypeOnlyStatementStart(kind: "type" | "interface"): boolean {

--- a/test/api-methods.test.ts
+++ b/test/api-methods.test.ts
@@ -112,6 +112,23 @@ describe("Interpreter", () => {
         expect(() => interpreter.parse("function () {}")).toThrow();
       });
 
+      it("should reject unsupported TypeScript enum and namespace declarations", () => {
+        const interpreter = new Interpreter();
+
+        expect(() => interpreter.parse("enum Color { Red, Blue }")).toThrow(
+          "TypeScript 'enum' declarations are not supported",
+        );
+        expect(() => interpreter.parse("namespace Foo { export const x = 1; }")).toThrow(
+          "TypeScript 'namespace' declarations are not supported",
+        );
+        expect(() => interpreter.evaluate("enum Color { Red, Blue }")).toThrow(
+          "TypeScript 'enum' declarations are not supported",
+        );
+        expect(() => interpreter.evaluate("namespace Foo { export const x = 1; }")).toThrow(
+          "TypeScript 'namespace' declarations are not supported",
+        );
+      });
+
       it("should parse without executing", () => {
         const interpreter = new Interpreter();
 

--- a/test/ast.test.ts
+++ b/test/ast.test.ts
@@ -551,6 +551,18 @@ describe("AST", () => {
         expect(() => parseModule("continue label;")).not.toThrow();
       });
 
+      it("rejects unsupported TypeScript enum declarations", () => {
+        expect(() => parseScript("enum Color { Red, Blue }")).toThrow(
+          "TypeScript 'enum' declarations are not supported",
+        );
+      });
+
+      it("rejects unsupported TypeScript namespace declarations", () => {
+        expect(() => parseScript("namespace Foo { export const x = 1; }")).toThrow(
+          "TypeScript 'namespace' declarations are not supported",
+        );
+      });
+
       it("rejects private identifiers in object literals", () => {
         expect(() => parseModule("let obj = { #x: 1 };")).toThrow();
       });


### PR DESCRIPTION
## Summary
- reject TypeScript `enum` and `namespace` declaration syntax at statement start with a `ParseError`
- keep the check targeted to declaration forms so regular identifier parsing is unchanged
- add regression coverage for both direct parsing and interpreter parse/evaluate entry points
- include a patch changeset for the fix

## Problem
Issue #162 reported that unsupported TypeScript-only syntax like `enum Color { Red, Blue }` and `namespace Foo { ... }` was being tokenized and parsed into ordinary statements, which then failed later at runtime with undefined identifier errors. That made `parse()` accept syntax the docs explicitly describe as unsupported and made the failure mode misleading.

## Solution
This change adds a parser lookahead for `enum` and `namespace` declaration forms before statement parsing falls back to expression statements. When those forms are detected, the parser now throws a clear `ParseError` immediately.

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun lint` (passes with 2 pre-existing warnings outside this change)
- `bun typecheck`
- `bun test`

Closes #162
