### PR TITLE
fix: strip TypeScript satisfies expressions in the parser

### DIFF
--- a/.changeset/issue-163-strip-satisfies.md
+++ b/.changeset/issue-163-strip-satisfies.md
@@ -1,0 +1,7 @@
+---
+"nookjs": patch
+---
+
+Strip TypeScript `satisfies` expressions during parsing so modern TS code like
+`const x = { a: 1 } satisfies { a: number }` preserves JavaScript runtime behavior instead of
+failing on an undefined `satisfies` identifier.

--- a/docs/AST_PARSER.md
+++ b/docs/AST_PARSER.md
@@ -24,7 +24,7 @@ Type syntax is parsed and discarded so runtime behavior matches plain JavaScript
 
 - Generic parameter lists on functions, classes, and methods
 - Variable/parameter/property annotations and function return types
-- `as` assertions
+- `as` assertions and `satisfies` expressions
 - Optional (`?`) and definite assignment (`!`) markers
 - `implements` clauses
 - `type` and `interface` declarations (parsed and dropped)

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -3168,10 +3168,10 @@ class Parser {
   }
 
   private consumeTypeAssertions(expression: ESTree.Expression): ESTree.Expression {
-    if (this.currentType !== TOKEN.Identifier || this.currentValue !== "as") {
+    if (!this.isTypeAssertionOperator()) {
       return expression;
     }
-    while (this.currentType === TOKEN.Identifier && this.currentValue === "as") {
+    while (this.isTypeAssertionOperator()) {
       this.next();
       this.skipType(STOP_TOKEN.Assertion);
       if (this.currentType !== TOKEN.Identifier) {
@@ -3185,6 +3185,13 @@ class Parser {
     if (this.currentType === TOKEN.Punctuator && this.currentValue === "<") {
       this.skipType(stopTokens);
     }
+  }
+
+  private isTypeAssertionOperator(): boolean {
+    if (this.currentType !== TOKEN.Identifier) {
+      return false;
+    }
+    return this.currentValue === "as" || this.currentValue === "satisfies";
   }
 
   private consumeTypeScriptModifiers(): void {

--- a/test/ast.test.ts
+++ b/test/ast.test.ts
@@ -333,6 +333,14 @@ describe("AST", () => {
         expect(init.type).toBe("ArrowFunctionExpression");
       });
 
+      it("strips satisfies expressions", () => {
+        const ast = parseModule("const x = { a: 1 } satisfies { a: number }; x.a;");
+
+        expect(ast.body).toHaveLength(2);
+        expect(ast.body[0]?.type).toBe("VariableDeclaration");
+        expect(ast.body[1]?.type).toBe("ExpressionStatement");
+      });
+
       it("parses class fields with modifiers and implements clauses", () => {
         const stmt = parseFirstStatement(`
         class Box implements Sized {
@@ -456,6 +464,16 @@ describe("AST", () => {
         `);
 
         expect(result).toEqual([1, 2]);
+      });
+
+      it("preserves runtime behavior when stripping satisfies expressions", () => {
+        const interpreter = new Interpreter();
+        const result = interpreter.evaluate(`
+          const x = { a: 1 } satisfies { a: number };
+          x.a;
+        `);
+
+        expect(result).toBe(1);
       });
     });
 


### PR DESCRIPTION
## Summary
- strip TypeScript `satisfies` clauses in the existing type-assertion parser path
- add regression coverage for both AST parsing and interpreter evaluation
- document `satisfies` support in the AST parser docs and add a patch changeset

## Testing
- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun typecheck`
- `bun test`

Closes #163