### PR TITLE
[codex] Fix maxEvaluations enforcement for zero-budget evaluations

### DIFF
--- a/.changeset/fresh-forks-kick.md
+++ b/.changeset/fresh-forks-kick.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Enforce `maxEvaluations` before starting an evaluation so a limit of `0` blocks the first `evaluate()` call and evaluation budgets are applied exactly.

--- a/src/resource-tracker.ts
+++ b/src/resource-tracker.ts
@@ -167,6 +167,13 @@ export class ResourceTracker {
         this.limits[this.exhaustedLimit] ?? 0,
       );
     }
+
+    const maxEvaluations = this.limits.maxEvaluations;
+    const nextEvaluationNumber = this.evaluationNumber + 1;
+    if (maxEvaluations !== undefined && nextEvaluationNumber > maxEvaluations) {
+      this.exhaustedLimit = "maxEvaluations";
+      throw new ResourceExhaustedError("maxEvaluations", nextEvaluationNumber, maxEvaluations);
+    }
   }
 
   endEvaluation(

--- a/test/resource-tracker.test.ts
+++ b/test/resource-tracker.test.ts
@@ -153,19 +153,54 @@ describe("Resource Tracking", () => {
           }).toThrow(ResourceExhaustedError);
         });
 
-        test("should throw when maxEvaluations exceeded", () => {
+        test("should reject the first evaluation when maxEvaluations is 0", () => {
           const interpreter = new Interpreter({
             ...ES2022,
             resourceTracking: true,
           });
-          interpreter.setResourceLimit("maxEvaluations", 2);
+          interpreter.setResourceLimit("maxEvaluations", 0);
+
+          expect(() => {
+            interpreter.evaluate("1 + 1");
+          }).toThrow(ResourceExhaustedError);
+
+          const stats = interpreter.getResourceStats();
+          expect(stats.evaluations).toBe(0);
+          expect(stats.isExhausted).toBe(true);
+        });
+
+        test("should allow exactly one evaluation when maxEvaluations is 1", () => {
+          const interpreter = new Interpreter({
+            ...ES2022,
+            resourceTracking: true,
+          });
+          interpreter.setResourceLimit("maxEvaluations", 1);
+
+          expect(interpreter.evaluate("1 + 1")).toBe(2);
+
+          expect(() => {
+            interpreter.evaluate("2 + 2");
+          }).toThrow(ResourceExhaustedError);
+
+          expect(interpreter.getResourceStats().evaluations).toBe(1);
+        });
+
+        test("should allow evaluations up to the configured maxEvaluations budget", () => {
+          const interpreter = new Interpreter({
+            ...ES2022,
+            resourceTracking: true,
+          });
+          interpreter.setResourceLimit("maxEvaluations", 3);
 
           interpreter.evaluate("1 + 1");
           interpreter.evaluate("2 + 2");
+          interpreter.evaluate("3 + 3");
 
           expect(() => {
-            interpreter.evaluate("3 + 3");
+            interpreter.evaluate("4 + 4");
           }).toThrow(ResourceExhaustedError);
+
+          expect(interpreter.getResourceStats().evaluations).toBe(3);
         });
 
         test("should throw when maxFunctionCalls exceeded", () => {


### PR DESCRIPTION
## Summary

Fix `ResourceTracker` so `maxEvaluations` is enforced before an evaluation starts. This closes the off-by-one gap where a limit of `0` still allowed the first `evaluate()` call to run.

Closes #181.

## Root cause

`beginEvaluation()` only checked whether a limit had already been marked exhausted, while `evaluationNumber` was incremented later in `endEvaluation()`. That meant the first evaluation could start even when the configured budget was already `0`.

## What changed

- reject a new evaluation in `beginEvaluation()` when `evaluationNumber + 1` would exceed `maxEvaluations`
- preserve the existing post-evaluation accounting and history behavior
- add regression tests covering `maxEvaluations` values of `0`, `1`, and a larger budget
- add a patch changeset for the fix

## Validation

- `bun test test/resource-tracker.test.ts`
- `bun fmt`
- `bun lint:fix`
- `bun lint`
- `bun fmt:check`
- `bun typecheck`
- `bun test`
