### PR TITLE
[codex] Fix importer-aware module introspection for ambiguous specifiers

### DIFF
--- a/.changeset/clever-timers-ring.md
+++ b/.changeset/clever-timers-ring.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Preserve importer-aware module introspection when the same specifier resolves to different cached paths, and require importer context for ambiguous specifier-based cache lookups.

--- a/docs/INTERNAL_CLASSES.md
+++ b/docs/INTERNAL_CLASSES.md
@@ -70,8 +70,13 @@ console.log(exports.result); // 3
 interpreter.isModuleCached("math.js");
 interpreter.getLoadedModuleSpecifiers();
 interpreter.getModuleMetadata("math.js");
+interpreter.getModuleMetadata("./x", { importer: "/modules/a.js" });
 interpreter.clearModuleCache();
 ```
+
+If a specifier resolves to different canonical paths depending on the importer, bare
+specifier-based lookups become ambiguous. In that case, use path-based helpers or pass
+`{ importer }` to the specifier-based methods.
 
 ## ResourceTracker (Standalone)
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -408,6 +408,20 @@ const sandbox = createSandbox({
 Module cache introspection and management are available on the internal `Interpreter` class.
 See [Internal Classes](INTERNAL_CLASSES.md) for details.
 
+Specifier-based introspection is only unambiguous when a specifier maps to exactly one cached
+path. If the same textual specifier resolves differently from different importers, bare
+specifier lookups return `undefined` or `false` and you should either:
+
+- use path-based introspection (`getModuleMetadataByPath()`, `getModuleExports()`,
+  `isModuleCachedByPath()`)
+- provide importer context to the specifier-based helpers
+
+```typescript
+interpreter.getModuleMetadata("./x", { importer: "/modules/a.js" });
+interpreter.getModuleExportsBySpecifier("./x", { importer: "/modules/b.js" });
+interpreter.isModuleCached("./x", { importer: "/modules/a.js" });
+```
+
 ## Lifecycle Hooks
 
 Monitor module loading with resolver hooks:

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ export {
 } from "./sandbox";
 
 export type {
+  ModuleIntrospectionContext,
   ModuleResolver,
   ModuleResolverContext,
   ModuleOptions,

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -15,7 +15,12 @@
 
 import type { ESTree, Location } from "./ast";
 import type { StackFrame } from "./errors";
-import type { ModuleOptions, ModuleMetadata, ModuleRecord } from "./modules";
+import type {
+  ModuleIntrospectionContext,
+  ModuleOptions,
+  ModuleMetadata,
+  ModuleRecord,
+} from "./modules";
 import type { NativeUnwrapAllowlistEntry } from "./readonly-proxy";
 
 import { parseModule, parseScript } from "./ast";
@@ -4151,11 +4156,11 @@ export class Interpreter {
         moduleRecord.importMeta,
         moduleRecord.exports,
       );
-      this.moduleSystem.setModuleExports(specifier, exports);
+      this.moduleSystem.setModuleExports(moduleRecord.path, exports);
       return exports;
     } catch (error) {
       const moduleError = error instanceof Error ? error : new Error(String(error));
-      this.moduleSystem.setModuleFailed(specifier, moduleError);
+      this.moduleSystem.setModuleFailed(moduleRecord.path, moduleError);
       throw error;
     }
   }
@@ -4447,6 +4452,7 @@ export class Interpreter {
    * Get the exports of a previously loaded module by its import specifier.
    *
    * @param specifier - The module specifier as used in import statements
+   * @param context - Optional importer context for specifiers that resolve differently by importer
    * @returns The module's exports, or undefined if not cached or not yet initialized
    *
    * @example
@@ -4458,8 +4464,11 @@ export class Interpreter {
    * const utilsExports = interpreter.getModuleExportsBySpecifier("./utils.js");
    * ```
    */
-  getModuleExportsBySpecifier(specifier: string): Record<string, any> | undefined {
-    return this.moduleSystem?.getModuleExportsBySpecifier(specifier);
+  getModuleExportsBySpecifier(
+    specifier: string,
+    context?: ModuleIntrospectionContext,
+  ): Record<string, any> | undefined {
+    return this.moduleSystem?.getModuleExportsBySpecifier(specifier, context);
   }
 
   /**
@@ -4483,10 +4492,11 @@ export class Interpreter {
    * Check if a module is cached by its import specifier.
    *
    * @param specifier - The module specifier as used in import statements
+   * @param context - Optional importer context for specifiers that resolve differently by importer
    * @returns true if the module has been resolved and cached
    */
-  isModuleCached(specifier: string): boolean {
-    return this.moduleSystem?.isModuleCached(specifier) ?? false;
+  isModuleCached(specifier: string, context?: ModuleIntrospectionContext): boolean {
+    return this.moduleSystem?.isModuleCached(specifier, context) ?? false;
   }
 
   /**
@@ -4521,6 +4531,7 @@ export class Interpreter {
    * Get metadata about a loaded module by its specifier.
    *
    * @param specifier - The module specifier as used in import statements
+   * @param context - Optional importer context for specifiers that resolve differently by importer
    * @returns Module metadata including path, status, and load time, or undefined if not cached
    *
    * @example
@@ -4532,8 +4543,11 @@ export class Interpreter {
    * }
    * ```
    */
-  getModuleMetadata(specifier: string): ModuleMetadata | undefined {
-    return this.moduleSystem?.getModuleMetadata(specifier);
+  getModuleMetadata(
+    specifier: string,
+    context?: ModuleIntrospectionContext,
+  ): ModuleMetadata | undefined {
+    return this.moduleSystem?.getModuleMetadata(specifier, context);
   }
 
   /**

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -243,6 +243,16 @@ export interface ModuleImportMetaContext {
 }
 
 /**
+ * Optional context for importer-aware module introspection.
+ */
+export interface ModuleIntrospectionContext {
+  /** The path of the module that imported the specifier, or null for entry point */
+  importer?: string | null;
+  /** Optional full importer chain when resolution depends on more than the importer alone */
+  importerChain?: readonly string[];
+}
+
+/**
  * Resolver interface for loading modules.
  *
  * Implementors control which modules can be loaded and how they are resolved.
@@ -366,8 +376,10 @@ function shallowCloneWithDescriptors<T extends object>(obj: T): T {
 export class ModuleSystem {
   // Cache by resolved path, not specifier (fixes cache key collision)
   private cacheByPath: Map<string, ModuleRecord> = new Map();
-  // Secondary index: specifier -> path (for specifier-based lookups)
-  private specifierToPath: Map<string, string> = new Map();
+  // Secondary index: specifier -> all resolved paths seen for that textual specifier.
+  private specifierToPaths: Map<string, Set<string>> = new Map();
+  // Importer-aware index used by public introspection when a specifier is context-sensitive.
+  private specifierToPathsByImporter: Map<string, Map<string | null, Set<string>>> = new Map();
   // Context-specific index for reusing cached module paths without re-running resolve()
   private resolvedPathByContext = new ResolutionContextPathCache(
     MAX_RESOLVED_PATH_CONTEXT_CACHE_SIZE,
@@ -440,6 +452,58 @@ export class ModuleSystem {
     this.resolvedPathByContext.delete(specifier, importer, importerChain);
   }
 
+  private registerSpecifierPath(specifier: string, importer: string | null, path: string): void {
+    let paths = this.specifierToPaths.get(specifier);
+    if (!paths) {
+      paths = new Set();
+      this.specifierToPaths.set(specifier, paths);
+    }
+    paths.add(path);
+
+    let pathsByImporter = this.specifierToPathsByImporter.get(specifier);
+    if (!pathsByImporter) {
+      pathsByImporter = new Map();
+      this.specifierToPathsByImporter.set(specifier, pathsByImporter);
+    }
+
+    let importerPaths = pathsByImporter.get(importer);
+    if (!importerPaths) {
+      importerPaths = new Set();
+      pathsByImporter.set(importer, importerPaths);
+    }
+    importerPaths.add(path);
+  }
+
+  private getUnambiguousPath(paths?: ReadonlySet<string>): string | undefined {
+    if (!paths || paths.size !== 1) {
+      return undefined;
+    }
+
+    return paths.values().next().value;
+  }
+
+  private getPathForSpecifier(
+    specifier: string,
+    context?: ModuleIntrospectionContext,
+  ): string | undefined {
+    if (context?.importerChain) {
+      return this.getResolvedPathForContext(
+        specifier,
+        context.importer ?? null,
+        context.importerChain,
+      );
+    }
+
+    if (context && Object.hasOwn(context, "importer")) {
+      const importerPaths = this.specifierToPathsByImporter
+        .get(specifier)
+        ?.get(context.importer ?? null);
+      return this.getUnambiguousPath(importerPaths);
+    }
+
+    return this.getUnambiguousPath(this.specifierToPaths.get(specifier));
+  }
+
   async resolveModule(specifier: string, importer: string | null): Promise<ModuleRecord | null> {
     if (!this.options.enabled) {
       throw new Error("Module system is not enabled");
@@ -487,7 +551,13 @@ export class ModuleSystem {
               return null;
             }
 
-            this.specifierToPath.set(specifier, cachedPath);
+            this.registerSpecifierPath(specifier, importer, cachedPath);
+            this.cacheResolvedPathForContext(
+              specifier,
+              importer,
+              context.importerChain,
+              cachedPath,
+            );
             return existingByPath;
           }
 
@@ -516,12 +586,11 @@ export class ModuleSystem {
       // Cache key is the resolved path (source.path), not the specifier,
       // to ensure cache entries are tied to the specific resolved module.
       if (this.options.cache) {
-        // Preserve all successfully authorized specifiers, even when they
-        // resolve to a module path that is already cached.
-        this.specifierToPath.set(specifier, source.path);
-
         const existingByPath = this.cacheByPath.get(source.path);
         if (existingByPath) {
+          // Preserve all successfully authorized specifiers, even when they
+          // resolve to a module path that is already cached.
+          this.registerSpecifierPath(specifier, importer, source.path);
           this.cacheResolvedPathForContext(specifier, importer, context.importerChain, source.path);
           // If already initialized, return cached exports
           if (existingByPath.status === "initialized") {
@@ -559,6 +628,7 @@ export class ModuleSystem {
 
       if (this.options.cache) {
         this.cacheByPath.set(source.path, record);
+        this.registerSpecifierPath(specifier, importer, source.path);
         this.cacheResolvedPathForContext(specifier, importer, context.importerChain, source.path);
       }
 
@@ -605,8 +675,11 @@ export class ModuleSystem {
   /**
    * Get module exports by specifier.
    */
-  getModuleExportsBySpecifier(specifier: string): Record<string, any> | undefined {
-    const path = this.specifierToPath.get(specifier);
+  getModuleExportsBySpecifier(
+    specifier: string,
+    context?: ModuleIntrospectionContext,
+  ): Record<string, any> | undefined {
+    const path = this.getPathForSpecifier(specifier, context);
     if (path) {
       return this.getModuleExports(path);
     }
@@ -620,31 +693,25 @@ export class ModuleSystem {
    * which provides mutation protection. We store them directly without additional
    * freezing since the proxy already blocks mutations.
    */
-  setModuleExports(specifier: string, exports: Record<string, any>): void {
-    const path = this.specifierToPath.get(specifier);
-    if (!path) return;
-
+  setModuleExports(path: string, exports: Record<string, any>): void {
     const record = this.cacheByPath.get(path);
     if (record) {
       // Exports are already protected by ReadOnlyProxy from evaluateModuleAstAsync
       record.exports = exports;
       record.status = "initialized";
-      this.options.resolver.onLoad?.(specifier, path, record.exports);
+      this.options.resolver.onLoad?.(record.specifier, path, record.exports);
     }
   }
 
   /**
    * Mark a module as failed.
    */
-  setModuleFailed(specifier: string, error: Error): void {
-    const path = this.specifierToPath.get(specifier);
-    if (!path) return;
-
+  setModuleFailed(path: string, error: Error): void {
     const record = this.cacheByPath.get(path);
     if (record) {
       record.status = "failed";
       record.error = error;
-      this.options.resolver.onError?.(specifier, null, error);
+      this.options.resolver.onError?.(record.specifier, null, error);
     }
   }
 
@@ -653,7 +720,8 @@ export class ModuleSystem {
    */
   clearCache(): void {
     this.cacheByPath.clear();
-    this.specifierToPath.clear();
+    this.specifierToPaths.clear();
+    this.specifierToPathsByImporter.clear();
     this.resolvedPathByContext.clear();
     this.evaluationStack = [];
   }
@@ -679,8 +747,8 @@ export class ModuleSystem {
   /**
    * Check if a module is cached (by specifier).
    */
-  isModuleCached(specifier: string): boolean {
-    return this.specifierToPath.has(specifier);
+  isModuleCached(specifier: string, context?: ModuleIntrospectionContext): boolean {
+    return this.getPathForSpecifier(specifier, context) !== undefined;
   }
 
   /**
@@ -701,14 +769,17 @@ export class ModuleSystem {
    * Get a list of all registered specifiers.
    */
   getLoadedSpecifiers(): string[] {
-    return Array.from(this.specifierToPath.keys());
+    return Array.from(this.specifierToPaths.keys());
   }
 
   /**
    * Get metadata about a loaded module.
    */
-  getModuleMetadata(specifier: string): ModuleMetadata | undefined {
-    const path = this.specifierToPath.get(specifier);
+  getModuleMetadata(
+    specifier: string,
+    context?: ModuleIntrospectionContext,
+  ): ModuleMetadata | undefined {
+    const path = this.getPathForSpecifier(specifier, context);
     if (!path) return undefined;
 
     const record = this.cacheByPath.get(path);

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -344,6 +344,7 @@ export interface ModuleMetadata {
 }
 
 export interface ModuleRecord {
+  importer: string | null;
   path: string;
   specifier: string;
   exports: Record<string, any>;
@@ -608,6 +609,7 @@ export class ModuleSystem {
       }
 
       const record: ModuleRecord = {
+        importer,
         path: source.path,
         specifier,
         exports: {},
@@ -711,7 +713,7 @@ export class ModuleSystem {
     if (record) {
       record.status = "failed";
       record.error = error;
-      this.options.resolver.onError?.(record.specifier, null, error);
+      this.options.resolver.onError?.(record.specifier, record.importer, error);
     }
   }
 

--- a/test/modules.test.ts
+++ b/test/modules.test.ts
@@ -3240,6 +3240,67 @@ describe("Module System", () => {
       expect(badModuleEvaluations).toBe(1);
     });
 
+    test("should preserve importer attribution for failed module onError callbacks", async () => {
+      const errors: Array<{ specifier: string; importer: string | null; message: string }> = [];
+
+      const resolver: ModuleResolver = {
+        resolve(specifier) {
+          if (specifier === "dep.js") {
+            return {
+              type: "source",
+              code: `boom;`,
+              path: "/modules/dep.js",
+            };
+          }
+          if (specifier === "parent.js") {
+            return {
+              type: "source",
+              code: `import { value } from "dep.js"; export const parent = value;`,
+              path: "/modules/parent.js",
+            };
+          }
+          return null;
+        },
+        onError(specifier, importer, error) {
+          errors.push({
+            specifier,
+            importer,
+            message: error.message,
+          });
+        },
+      };
+
+      const interpreter = new Interpreter({
+        modules: { enabled: true, resolver, cache: true },
+      });
+
+      let thrownError: unknown;
+      try {
+        await interpreter.evaluateModuleAsync(
+          `import { parent } from "parent.js"; export { parent };`,
+          {
+            path: "main.js",
+          },
+        );
+      } catch (error) {
+        thrownError = error;
+      }
+
+      expect(thrownError).toBeDefined();
+      expect(thrownError).toBeInstanceOf(Error);
+      expect((thrownError as Error).message).toContain("Undefined variable 'boom'");
+
+      expect(errors).toEqual(
+        expect.arrayContaining([
+          {
+            specifier: "dep.js",
+            importer: "/modules/parent.js",
+            message: "Undefined variable 'boom'",
+          },
+        ]),
+      );
+    });
+
     test("should handle getLoadedModulePaths with multiple modules", async () => {
       const files = new Map([
         ["a.js", "export const a = 1;"],

--- a/test/modules.test.ts
+++ b/test/modules.test.ts
@@ -3104,6 +3104,70 @@ describe("Module System", () => {
       expect(interpreter.getModuleExportsBySpecifier("./a.js")?.value).toBe(1);
     });
 
+    test("should require importer context when a specifier resolves to multiple paths", async () => {
+      const resolver: ModuleResolver = {
+        resolve(specifier, importer) {
+          if (specifier === "a.js") {
+            return {
+              type: "source",
+              code: `import { value } from "./x"; export const a = value;`,
+              path: "/modules/a.js",
+            };
+          }
+          if (specifier === "b.js") {
+            return {
+              type: "source",
+              code: `import { value } from "./x"; export const b = value;`,
+              path: "/modules/b.js",
+            };
+          }
+          if (specifier === "./x" && importer === "/modules/a.js") {
+            return {
+              type: "source",
+              code: `export const value = "from-a";`,
+              path: "/modules/a/x.js",
+            };
+          }
+          if (specifier === "./x" && importer === "/modules/b.js") {
+            return {
+              type: "source",
+              code: `export const value = "from-b";`,
+              path: "/modules/b/x.js",
+            };
+          }
+          return null;
+        },
+      };
+
+      const interpreter = new Interpreter({
+        modules: { enabled: true, resolver, cache: true },
+      });
+
+      const result = await interpreter.evaluateModuleAsync(
+        'import { a } from "a.js"; import { b } from "b.js"; export const values = [a, b];',
+        { path: "main.js" },
+      );
+
+      expect(result.values).toEqual(["from-a", "from-b"]);
+      expect(interpreter.isModuleCached("./x")).toBe(false);
+      expect(interpreter.getModuleMetadata("./x")).toBeUndefined();
+      expect(interpreter.getModuleExportsBySpecifier("./x")).toBeUndefined();
+      expect(interpreter.isModuleCached("./x", { importer: "/modules/a.js" })).toBe(true);
+      expect(interpreter.isModuleCached("./x", { importer: "/modules/b.js" })).toBe(true);
+      expect(interpreter.getModuleMetadata("./x", { importer: "/modules/a.js" })?.path).toBe(
+        "/modules/a/x.js",
+      );
+      expect(interpreter.getModuleMetadata("./x", { importer: "/modules/b.js" })?.path).toBe(
+        "/modules/b/x.js",
+      );
+      expect(
+        interpreter.getModuleExportsBySpecifier("./x", { importer: "/modules/a.js" })?.value,
+      ).toBe("from-a");
+      expect(
+        interpreter.getModuleExportsBySpecifier("./x", { importer: "/modules/b.js" })?.value,
+      ).toBe("from-b");
+    });
+
     test("should return undefined metadata for non-existent module", async () => {
       const resolver: ModuleResolver = {
         resolve() {

--- a/www/src/pages/docs/modules.tsx
+++ b/www/src/pages/docs/modules.tsx
@@ -390,6 +390,16 @@ const noCacheSandbox = createSandbox({
           </Link>{" "}
           for advanced control.
         </p>
+        <p className="text-neutral-300 mb-4">
+          Bare specifier lookups are only meaningful when that specifier maps to one cached module
+          path. If resolution depends on the importer, use path-based helpers or pass importer
+          context to the specifier-based methods.
+        </p>
+        <CodeBlock
+          code={`interpreter.getModuleMetadata("./x", { importer: "/modules/a.js" });
+interpreter.getModuleExportsBySpecifier("./x", { importer: "/modules/b.js" });
+interpreter.isModuleCached("./x", { importer: "/modules/a.js" });`}
+        />
       </section>
 
       <section className="mb-12">


### PR DESCRIPTION
## Summary

Fix module introspection when the same textual specifier resolves to different canonical module paths depending on the importer.

Closes #182.

## Root Cause

`ModuleSystem` stored a single global `specifier -> path` alias for specifier-based cache introspection. When two different importers resolved the same specifier string to different paths, the later resolution overwrote the earlier one, making `getModuleMetadata()`, `getModuleExportsBySpecifier()`, and `isModuleCached()` report misleading results.

## What Changed

- replace the lossy single-path alias with ambiguity-aware specifier indexes
- preserve unambiguous specifier aliases while treating ambiguous bare-specifier lookups as undefined/false
- add optional importer context to specifier-based introspection helpers so callers can resolve importer-sensitive specifiers correctly
- stop module export/failure finalization from depending on the lossy specifier alias
- add a regression test covering the same specifier resolving differently from two importers
- document the new introspection semantics and add a patch changeset

## Validation

- `bun run fmt`
- `bun run lint:fix`
- `bun test`
- `bun run typecheck`