### PR TITLE
[codex] Fix evaluateSteps lifecycle parity

### DIFF
--- a/.changeset/bright-plants-wave.md
+++ b/.changeset/bright-plants-wave.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Route `evaluateSteps()` through the standard evaluation lifecycle so stepping respects per-call validators, globals, and execution limits while preserving integrated resource tracking, cleanup, and normal error enhancement.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -3688,8 +3688,8 @@ export class Interpreter {
     options?: EvaluateOptions,
   ): Generator<ExecutionStep, void, void> {
     const sourceCode = typeof input === "string" ? input : "pre-parsed AST";
-    const releaseMutex = this.acquireSyncEvaluationMutexIfNeeded();
     const cleanupToken = {};
+    let releaseMutex: (() => void) | undefined;
     let ast: ESTree.Program | undefined;
     let initialized = false;
     let finalized = false;
@@ -3738,6 +3738,7 @@ export class Interpreter {
 
     const initialize = () => {
       this.closeAbandonedStepEvaluation();
+      releaseMutex = this.acquireSyncEvaluationMutexIfNeeded();
       this.assertSyncSignalIsDisabled(options);
       this.currentSourceCode = sourceCode;
       this.callStack = [];

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -3648,7 +3648,8 @@ export class Interpreter {
    * This allows you to step through code execution one statement at a time,
    * inspecting the interpreter state at each step.
    *
-   * @param code - The JavaScript code to evaluate
+   * @param input - The JavaScript code or pre-parsed AST to evaluate
+   * @param options - Optional evaluation controls such as validators, globals, and limits
    * @returns A generator that yields ExecutionStep objects
    *
    * @example
@@ -3668,42 +3669,66 @@ export class Interpreter {
    * }
    * ```
    */
-  *evaluateSteps(code: string): Generator<ExecutionStep, void, void> {
-    const ast = this.parse(code);
-
-    // Reset statistics
-    this.statsNodeCount = 0;
-    this.statsFunctionCalls = 0;
-    this.statsLoopIterations = 0;
-    this.statsStartTime = performance.now();
-
-    let result: any;
-
-    for (const statement of ast.body) {
-      // Yield before executing each top-level statement
-      yield {
-        nodeType: statement.type,
-        line: statement.line,
-        done: false,
-      };
-
-      result = this.evaluateNode(statement);
-
-      // Handle control flow values
-      if (isControlFlowKind(result, "return")) {
-        result = result.value;
-        break;
+  *evaluateSteps(
+    input: string | ESTree.Program,
+    options?: EvaluateOptions,
+  ): Generator<ExecutionStep, void, void> {
+    const releaseMutex = this.acquireSyncEvaluationMutexIfNeeded();
+    const sourceCode = typeof input === "string" ? input : "pre-parsed AST";
+    this.currentSourceCode = sourceCode;
+    this.callStack = [];
+    let evaluationStarted = false;
+    try {
+      this.assertSyncSignalIsDisabled(options);
+      this.beginEvaluation(options);
+      evaluationStarted = true;
+      const ast = this.parseAndValidate(input, options);
+      const needsFreshScope = typeof input !== "string";
+      const previousEnv = this.environment;
+      if (needsFreshScope) {
+        this.environment = new Environment(this.environment);
       }
+      try {
+        let result: any;
+
+        for (const statement of ast.body) {
+          // Yield before executing each top-level statement.
+          yield {
+            nodeType: statement.type,
+            line: statement.line,
+            done: false,
+          };
+
+          result = this.evaluateNode(statement);
+
+          // Handle control flow values.
+          if (isControlFlowKind(result, "return")) {
+            result = result.value;
+            break;
+          }
+        }
+
+        // Final step with the result.
+        yield {
+          nodeType: "Program",
+          done: true,
+          result,
+        };
+      } finally {
+        if (needsFreshScope) {
+          this.environment = previousEnv;
+        }
+      }
+    } catch (error) {
+      throw this.enhanceError(error);
+    } finally {
+      if (evaluationStarted) {
+        this.endEvaluation(options);
+      }
+      this.currentSourceCode = "";
+      this.callStack = [];
+      releaseMutex?.();
     }
-
-    this.statsEndTime = performance.now();
-
-    // Final step with the result
-    yield {
-      nodeType: "Program",
-      done: true,
-      result,
-    };
   }
 
   /**

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -115,6 +115,13 @@ class ControlFlowSignal {
 // Reuse a single marker instance to avoid per-chain allocations.
 const OPTIONAL_CHAIN_SHORT_CIRCUIT = new ControlFlowSignal("optional-chain");
 
+const STEP_EVALUATION_FINALIZER =
+  typeof FinalizationRegistry === "undefined"
+    ? undefined
+    : new FinalizationRegistry<() => void>((cleanup) => {
+        cleanup();
+      });
+
 const isControlFlowSignal = (value: any): value is ControlFlowSignal =>
   value instanceof ControlFlowSignal;
 
@@ -2658,6 +2665,7 @@ export class Interpreter {
   // Integrated resource tracking state
   private integratedResourceTracking = false;
   private integratedResourceTracker: ResourceTracker | null = null;
+  private activeStepEvaluationCleanup?: () => void;
 
   private moduleSystem: ModuleSystem | null = null;
   private moduleImportMetaStack: any[] = [];
@@ -2706,6 +2714,10 @@ export class Interpreter {
 
   private getCurrentContext(): EvaluationContext | undefined {
     return this.evaluationContextStack[this.evaluationContextStack.length - 1];
+  }
+
+  private closeAbandonedStepEvaluation(): void {
+    this.activeStepEvaluationCleanup?.();
   }
 
   private getCurrentValidator(): ASTValidator | undefined {
@@ -3362,6 +3374,7 @@ export class Interpreter {
   }
 
   evaluate(input: string | ESTree.Program, options?: EvaluateOptions): any {
+    this.closeAbandonedStepEvaluation();
     const releaseMutex = this.acquireSyncEvaluationMutexIfNeeded();
     const sourceCode = typeof input === "string" ? input : "pre-parsed AST";
     this.currentSourceCode = sourceCode;
@@ -3397,6 +3410,7 @@ export class Interpreter {
   }
 
   async evaluateAsync(input: string | ESTree.Program, options?: EvaluateOptions): Promise<any> {
+    this.closeAbandonedStepEvaluation();
     const releaseMutex = await this.acquireEvaluationMutex(options?.signal);
     const sourceCode = typeof input === "string" ? input : "pre-parsed AST";
     this.currentSourceCode = sourceCode;
@@ -3669,66 +3683,139 @@ export class Interpreter {
    * }
    * ```
    */
-  *evaluateSteps(
+  evaluateSteps(
     input: string | ESTree.Program,
     options?: EvaluateOptions,
   ): Generator<ExecutionStep, void, void> {
-    const releaseMutex = this.acquireSyncEvaluationMutexIfNeeded();
     const sourceCode = typeof input === "string" ? input : "pre-parsed AST";
-    this.currentSourceCode = sourceCode;
-    this.callStack = [];
-    let evaluationStarted = false;
-    try {
+    const releaseMutex = this.acquireSyncEvaluationMutexIfNeeded();
+    const cleanupToken = {};
+    let ast: ESTree.Program | undefined;
+    let initialized = false;
+    let finalized = false;
+    let emittedCompletion = false;
+    let currentIndex = 0;
+    let pendingStatementExecution = false;
+    let result: any;
+    let previousEnv: Environment | undefined;
+    let needsFreshScope = false;
+
+    const cleanup = () => {
+      if (finalized) {
+        return;
+      }
+      finalized = true;
+      if (this.activeStepEvaluationCleanup === cleanup) {
+        this.activeStepEvaluationCleanup = undefined;
+      }
+      STEP_EVALUATION_FINALIZER?.unregister(cleanupToken);
+      try {
+        if (initialized) {
+          if (needsFreshScope && previousEnv) {
+            this.environment = previousEnv;
+          }
+          this.endEvaluation(options);
+        }
+      } finally {
+        this.currentSourceCode = "";
+        this.callStack = [];
+        releaseMutex?.();
+      }
+    };
+
+    const completeWithResult = (value: any): IteratorResult<ExecutionStep, void> => {
+      emittedCompletion = true;
+      cleanup();
+      return {
+        done: false,
+        value: {
+          nodeType: "Program",
+          done: true,
+          result: value,
+        },
+      };
+    };
+
+    const initialize = () => {
+      this.closeAbandonedStepEvaluation();
       this.assertSyncSignalIsDisabled(options);
+      this.currentSourceCode = sourceCode;
+      this.callStack = [];
       this.beginEvaluation(options);
-      evaluationStarted = true;
-      const ast = this.parseAndValidate(input, options);
-      const needsFreshScope = typeof input !== "string";
-      const previousEnv = this.environment;
+      initialized = true;
+      this.activeStepEvaluationCleanup = cleanup;
+      STEP_EVALUATION_FINALIZER?.register(stepIterator, cleanup, cleanupToken);
+      ast = this.parseAndValidate(input, options);
+      needsFreshScope = typeof input !== "string";
+      previousEnv = this.environment;
       if (needsFreshScope) {
         this.environment = new Environment(this.environment);
       }
-      try {
-        let result: any;
+    };
 
-        for (const statement of ast.body) {
-          // Yield before executing each top-level statement.
-          yield {
-            nodeType: statement.type,
-            line: statement.line,
-            done: false,
-          };
+    const stepIterator: Generator<ExecutionStep, void, void> = {
+      next: () => {
+        if (emittedCompletion) {
+          return { done: true, value: undefined };
+        }
 
-          result = this.evaluateNode(statement);
-
-          // Handle control flow values.
-          if (isControlFlowKind(result, "return")) {
-            result = result.value;
-            break;
+        try {
+          if (!initialized) {
+            initialize();
+            if ((ast?.body.length ?? 0) === 0) {
+              return completeWithResult(undefined);
+            }
           }
-        }
 
-        // Final step with the result.
-        yield {
-          nodeType: "Program",
-          done: true,
-          result,
-        };
-      } finally {
-        if (needsFreshScope) {
-          this.environment = previousEnv;
+          if (pendingStatementExecution) {
+            const statement = ast!.body[currentIndex]!;
+            result = this.evaluateNode(statement);
+            pendingStatementExecution = false;
+
+            if (isControlFlowKind(result, "return")) {
+              return completeWithResult(result.value);
+            }
+
+            currentIndex++;
+            if (currentIndex >= ast!.body.length) {
+              return completeWithResult(result);
+            }
+          }
+
+          pendingStatementExecution = true;
+          const statement = ast!.body[currentIndex]!;
+          return {
+            done: false,
+            value: {
+              nodeType: statement.type,
+              line: statement.line,
+              done: false,
+            },
+          };
+        } catch (error) {
+          const enhancedError = this.enhanceError(error);
+          cleanup();
+          throw enhancedError;
         }
-      }
-    } catch (error) {
-      throw this.enhanceError(error);
-    } finally {
-      if (evaluationStarted) {
-        this.endEvaluation(options);
-      }
-      this.currentSourceCode = "";
-      this.callStack = [];
-      releaseMutex?.();
-    }
+      },
+      return: () => {
+        emittedCompletion = true;
+        cleanup();
+        return { done: true, value: undefined };
+      },
+      throw: (error?: any) => {
+        cleanup();
+        throw error;
+      },
+      [Symbol.dispose]: () => {
+        cleanup();
+      },
+      [Symbol.iterator]() {
+        return this;
+      },
+    };
+
+    return stepIterator;
   }
 
   /**
@@ -3841,6 +3928,7 @@ export class Interpreter {
     code: string,
     options: ModuleEvaluateOptions,
   ): Promise<Record<string, any>> {
+    this.closeAbandonedStepEvaluation();
     const releaseMutex = await this.acquireEvaluationMutex(options.signal);
     if (!this.moduleSystem) {
       releaseMutex();

--- a/test/api-methods.test.ts
+++ b/test/api-methods.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "bun:test";
 
 import type { ExecutionStats, ExecutionStep } from "../src/interpreter";
 
-import { Interpreter } from "../src/interpreter";
+import { Interpreter, InterpreterError } from "../src/interpreter";
 
 describe("Interpreter", () => {
   describe("API", () => {
@@ -430,6 +430,67 @@ describe("Interpreter", () => {
         }
 
         expect(steps.length).toBe(2);
+      });
+
+      it("should apply validators before stepping", () => {
+        const interpreter = new Interpreter();
+        const stepper = interpreter.evaluateSteps("let x = 1;", {
+          validator: () => false,
+        });
+
+        expect(() => stepper.next()).toThrow("AST validation failed");
+      });
+
+      it("should apply per-evaluation limits while stepping", () => {
+        const interpreter = new Interpreter();
+        const stepper = interpreter.evaluateSteps(
+          `
+          for (let i = 0; i < 3; i++) {
+            i;
+          }
+        `,
+          { maxLoopIterations: 1 },
+        );
+
+        expect(() => Array.from(stepper)).toThrow("Maximum loop iterations exceeded");
+      });
+
+      it("should enhance errors with source metadata while stepping", () => {
+        const interpreter = new Interpreter();
+        const code = "missingValue + 1;";
+        const stepper = interpreter.evaluateSteps(code);
+
+        expect(() => {
+          Array.from(stepper);
+        }).toThrow(
+          expect.objectContaining({
+            sourceCode: code,
+            callStack: [],
+          }),
+        );
+      });
+
+      it("should use standard evaluation cleanup for early-terminated stepping", () => {
+        const interpreter = new Interpreter({ resourceTracking: true });
+
+        for (const _step of interpreter.evaluateSteps("temp;", { globals: { temp: 42 } })) {
+          break;
+        }
+
+        expect("temp" in interpreter.getScope()).toBe(false);
+        expect(interpreter.getResourceStats().evaluations).toBe(1);
+      });
+
+      it("should preserve InterpreterError instances when enhancing step errors", () => {
+        const interpreter = new Interpreter();
+        const stepper = interpreter.evaluateSteps("unknownName;");
+
+        try {
+          Array.from(stepper);
+          throw new Error("expected stepper to throw");
+        } catch (error) {
+          expect(error).toBeInstanceOf(InterpreterError);
+        }
       });
     });
 

--- a/test/api-methods.test.ts
+++ b/test/api-methods.test.ts
@@ -481,6 +481,48 @@ describe("Interpreter", () => {
         expect(interpreter.getResourceStats().evaluations).toBe(1);
       });
 
+      it("should not start evaluation state before stepping begins", () => {
+        const interpreter = new Interpreter({ resourceTracking: true });
+
+        interpreter.evaluateSteps("temp;", { globals: { temp: 42 } });
+
+        expect("temp" in interpreter.getScope()).toBe(false);
+        expect(interpreter.getResourceStats().evaluations).toBe(0);
+      });
+
+      it("should clean up immediately after yielding the final completion step", () => {
+        const interpreter = new Interpreter({ resourceTracking: true });
+        const stepper = interpreter.evaluateSteps("temp;", { globals: { temp: 42 } });
+
+        expect(stepper.next().value).toMatchObject({
+          nodeType: "ExpressionStatement",
+          done: false,
+        });
+        expect(stepper.next().value).toMatchObject({
+          nodeType: "Program",
+          done: true,
+        });
+
+        expect("temp" in interpreter.getScope()).toBe(false);
+        expect(interpreter.getResourceStats().evaluations).toBe(1);
+      });
+
+      it("should clean up an abandoned step evaluation before a later evaluation starts", () => {
+        const interpreter = new Interpreter({ resourceTracking: true });
+        const stepper = interpreter.evaluateSteps("temp;", { globals: { temp: 42 } });
+
+        expect(stepper.next().value).toMatchObject({
+          nodeType: "ExpressionStatement",
+          done: false,
+        });
+        expect(interpreter.getScope().temp).toBe(42);
+
+        expect(interpreter.evaluate("1 + 1")).toBe(2);
+
+        expect("temp" in interpreter.getScope()).toBe(false);
+        expect(interpreter.getResourceStats().evaluations).toBe(2);
+      });
+
       it("should preserve InterpreterError instances when enhancing step errors", () => {
         const interpreter = new Interpreter();
         const stepper = interpreter.evaluateSteps("unknownName;");

--- a/test/strict-isolation.test.ts
+++ b/test/strict-isolation.test.ts
@@ -4,6 +4,14 @@ import { Interpreter } from "../src/interpreter";
 import { createSandbox } from "../src/sandbox";
 
 describe("Strict Evaluation Isolation", () => {
+  it("should not leak strict-isolation mutex when a stepper is never iterated", () => {
+    const interpreter = new Interpreter({ strictEvaluationIsolation: true });
+
+    interpreter.evaluateSteps("1 + 1");
+
+    expect(interpreter.evaluate("1 + 1")).toBe(2);
+  });
+
   it("should block sync evaluate() while async evaluation is pending", async () => {
     const gateState: { release: () => void } = { release: () => {} };
     const gate = new Promise<void>((resolve) => {


### PR DESCRIPTION
## Summary

Route `evaluateSteps()` through the same evaluation lifecycle used by `evaluate()` so step-by-step execution now respects standard per-call evaluation controls and cleanup.

## What changed

- reused `beginEvaluation()` / `endEvaluation()` inside `evaluateSteps()`
- added support for passing standard `EvaluateOptions` into `evaluateSteps()`
- aligned stepping with normal sync evaluation setup for source tracking, call stack reset, sync signal rejection, and fresh scope handling for pre-parsed AST input
- ensured generator teardown still runs when stepping stops early
- added regression tests covering validator enforcement, loop limits, enhanced error metadata, and early-termination cleanup with integrated resource tracking
- added a patch changeset

## Root cause

`evaluateSteps()` had its own direct parse-and-execute path. It manually reset a few stats fields, but skipped the standard lifecycle hooks that enforce per-evaluation limits, integrated resource tracking, per-call globals cleanup, and error enhancement.

## Impact

Stepping now behaves much closer to normal interpreter execution, which prevents inconsistencies between debug stepping and standard evaluation when callers rely on validators, limits, or resource accounting.

Fixes #183.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
