### PR TITLE
[codex] Fix getter-backed scope inspection for live module bindings

### DIFF
--- a/.changeset/slimy-baboons-build.md
+++ b/.changeset/slimy-baboons-build.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Fix `getScope()` so getter-backed bindings resolve through the normal environment read path, which makes scope inspection report the current value for module imports and other live bindings.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -3845,7 +3845,7 @@ export class Interpreter {
         for (const [name, entry] of vars) {
           // Don't overwrite variables from inner scopes
           if (!(name in scope)) {
-            scope[name] = (entry as any).value;
+            scope[name] = entry.getter ? env.get(name) : entry.value;
           }
         }
       }

--- a/test/api-methods.test.ts
+++ b/test/api-methods.test.ts
@@ -572,6 +572,56 @@ describe("Interpreter", () => {
         interpreter.evaluate("counter = 5;");
         expect(interpreter.getScope().counter).toBe(5);
       });
+
+      it("should resolve getter-backed module imports to their current values", async () => {
+        const capturedScopes: Array<Record<string, any>> = [];
+        const files = new Map<string, string>([
+          [
+            "counter.js",
+            `
+              export let value = 1;
+              export function setValue(next) {
+                value = next;
+              }
+            `,
+          ],
+        ]);
+
+        const interpreter = new Interpreter({
+          globals: {
+            captureScope() {
+              capturedScopes.push(interpreter.getScope());
+            },
+          },
+          modules: {
+            enabled: true,
+            resolver: {
+              resolve(specifier) {
+                const code = files.get(specifier);
+                if (!code) {
+                  return null;
+                }
+                return { type: "source", code, path: specifier };
+              },
+            },
+          },
+        });
+
+        await interpreter.evaluateModuleAsync(
+          `
+            import { value, setValue } from "counter.js";
+
+            captureScope();
+            setValue(2);
+            captureScope();
+          `,
+          { path: "main.js" },
+        );
+
+        expect(capturedScopes).toHaveLength(2);
+        expect(capturedScopes[0]?.value).toBe(1);
+        expect(capturedScopes[1]?.value).toBe(2);
+      });
     });
   });
 });


### PR DESCRIPTION
## Summary

Fix `Interpreter.getScope()` so getter-backed bindings resolve through the normal environment read path instead of returning the raw backing slot value.

## Root Cause

`Environment.declareGetter()` stores live bindings, including imported module bindings, as getter-backed entries. `Interpreter.getScope()` was bypassing that access path and reading `entry.value` directly, which meant scope inspection could report `undefined` or stale values even when normal interpreter reads returned the correct live binding value.

## What Changed

- update `getScope()` to resolve getter-backed bindings with the same environment read path used by ordinary variable access
- add an API regression test that captures scope during module execution and verifies imported live bindings update as their source module changes
- add a patch changeset for the bug fix

## Impact

Scope inspection now reflects the visible value of module imports and other getter-backed bindings, which makes debugging output consistent with runtime semantics.

## Validation

- `bun test test/api-methods.test.ts`
- `bun run fmt`
- `bun run lint:fix`
- `bun run typecheck`
- `bun test`

Closes #184