### PR TITLE
[codex] Reuse cached module paths without authorize()

### DIFF
--- a/.changeset/soft-balloons-count.md
+++ b/.changeset/soft-balloons-count.md
@@ -1,3 +1,4 @@
+---
 "nookjs": patch
 ---
 

--- a/.changeset/soft-balloons-count.md
+++ b/.changeset/soft-balloons-count.md
@@ -1,0 +1,4 @@
+"nookjs": patch
+---
+
+Reuse cached module-path lookups for repeated imports from the same resolution context even when a module resolver does not implement `authorize()`. This removes redundant `resolve()` calls while preserving the existing per-import re-authorization behavior when `authorize()` is present.

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -523,17 +523,16 @@ export class ModuleSystem {
     }
 
     try {
-      // Build resolver context. Without authorize(), resolve() stays the first gate
-      // so importer-aware access control can remain embedded in resolver logic.
-      // With authorize(), we can reuse a cached resolved path for the same context
-      // while still re-checking authorization before returning cached records.
+      // Build resolver context. Cached resolved paths are keyed by full resolution
+      // context so the fast path only applies when the same specifier/importer chain
+      // has already been resolved successfully.
       const context: ModuleResolverContext = {
         specifier,
         importer,
         importerChain: this.getImporterChain(),
       };
 
-      if (this.options.cache && this.options.resolver.authorize) {
+      if (this.options.cache) {
         const cachedPath = this.getResolvedPathForContext(
           specifier,
           importer,
@@ -542,14 +541,16 @@ export class ModuleSystem {
         if (cachedPath !== undefined) {
           const existingByPath = this.cacheByPath.get(cachedPath);
           if (existingByPath) {
-            const isAuthorized = await this.options.resolver.authorize(
-              specifier,
-              importer,
-              cachedPath,
-              context,
-            );
-            if (!isAuthorized) {
-              return null;
+            if (this.options.resolver.authorize) {
+              const isAuthorized = await this.options.resolver.authorize(
+                specifier,
+                importer,
+                cachedPath,
+                context,
+              );
+              if (!isAuthorized) {
+                return null;
+              }
             }
 
             this.registerSpecifierPath(specifier, importer, cachedPath);

--- a/test/modules.test.ts
+++ b/test/modules.test.ts
@@ -314,7 +314,7 @@ describe("Module System", () => {
         { path: "main.js" },
       );
 
-      expect(resolveCount).toBe(2);
+      expect(resolveCount).toBe(1);
       expect(exports.values).toEqual([1, 1]);
     });
 
@@ -493,7 +493,7 @@ describe("Module System", () => {
   });
 
   describe("Module Cache", () => {
-    test("should cache resolved modules by path after authorization", async () => {
+    test("should cache resolved modules by path after first resolution", async () => {
       let resolveCount = 0;
 
       const resolver: ModuleResolver = {
@@ -517,7 +517,7 @@ describe("Module System", () => {
         { path: "main.js" },
       );
 
-      expect(resolveCount).toBe(2);
+      expect(resolveCount).toBe(1);
     });
 
     test("should clear module cache", async () => {
@@ -1947,7 +1947,7 @@ describe("Module System", () => {
         { path: "main.js" },
       );
 
-      expect(evalCount).toBe(2);
+      expect(evalCount).toBe(1);
     });
 
     test("should maintain module state across imports", async () => {
@@ -4134,7 +4134,7 @@ describe("Module System", () => {
       ).rejects.toThrow("Cannot find module");
     });
 
-    test("should allow same importer to re-import same specifier (cache works for same context)", async () => {
+    test("should reuse cached module path for same importer when authorize hook is not implemented", async () => {
       let resolveCount = 0;
       const resolver: ModuleResolver = {
         resolve(specifier) {
@@ -4159,7 +4159,7 @@ describe("Module System", () => {
         { path: "main.js" },
       );
 
-      expect(resolveCount).toBe(2);
+      expect(resolveCount).toBe(1);
     });
 
     test("should use authorize hook to avoid repeated resolution for cached imports", async () => {


### PR DESCRIPTION
## Summary

Fix Issue #185 by reusing cached resolved module paths for repeated imports from the same resolution context even when the resolver does not implement `authorize()`.

## What changed

- relaxed the `resolveModule()` cached-path fast path so it can serve cached module records for no-`authorize()` resolvers
- kept the existing `authorize()` behavior intact by still re-checking authorization on every cached-path hit when that hook is present
- updated module regression coverage to assert single-resolution and single-evaluation behavior for repeated imports in the same context
- added a changeset describing the patch-level behavior change

## Why this changed

The resolved-path context cache was only being used when a resolver implemented `authorize()`. For resolvers that embed all access decisions directly in `resolve()`, repeated imports of the same module from the same importer still paid for another `resolve()` call even though the canonical module path was already known and cached.

## Root cause

`ModuleSystem.resolveModule()` gated the cached resolved-path fast path on `this.options.resolver.authorize`, which prevented cached context lookups from being reused for resolvers without that hook.

## Impact

Resolvers without `authorize()` now avoid redundant `resolve()` work for repeated imports in the same resolution context while preserving existing semantics for cached module reuse and keeping per-import authorization checks for resolvers that do provide `authorize()`.

Closes #185.

## Validation

- `bun run fmt`
- `bun run lint:fix`
- `bun run typecheck`
- `bun test`