### PR TITLE
[codex] Tighten execution-limit responsiveness around delegated work

### DIFF
--- a/.changeset/sixty-wolves-spark.md
+++ b/.changeset/sixty-wolves-spark.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Tighten `maxCpuTime` and async abort responsiveness around heavyweight delegated operations by forcing execution-limit checks before and after host/native calls, constructors, native property reads, tagged template invocation, and iterator delegation. Add regression coverage to ensure a single host call can no longer consume CPU budget or trip an `AbortSignal` without the active evaluation failing immediately.

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -208,6 +208,21 @@ export class FeatureError extends InterpreterError {
   }
 }
 
+export class ExecutionAbortedError extends InterpreterError {
+  constructor(options?: {
+    line?: number;
+    column?: number;
+    endLine?: number;
+    endColumn?: number;
+    code?: ErrorCode;
+    sourceCode?: string;
+    callStack?: StackFrame[];
+  }) {
+    super("Execution aborted", options);
+    this.name = "ExecutionAbortedError";
+  }
+}
+
 export function getSourceLine(sourceCode: string, line: number): string | null {
   const lines = sourceCode.split("\n");
   if (line < 1 || line > lines.length) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export type {
 } from "./interpreter";
 
 export {
+  ExecutionAbortedError,
   InterpreterError as InterpreterErrorBase,
   ParseError as ParseErrorBase,
   RuntimeError,

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -3082,18 +3082,20 @@ export class Interpreter {
    * Called at the start of each loop iteration and periodically during evaluation.
    * Only effective during async evaluation where the event loop can process signal changes.
    */
-  private checkExecutionLimits(): void {
+  private checkExecutionLimits(force = false): void {
     const abortSignal = this.getCurrentAbortSignal();
     const tracker = this.integratedResourceTracker;
     const maxCpuTime = tracker?.getLimit("maxCpuTime");
     if (!abortSignal && maxCpuTime === undefined) {
       return;
     }
-    // Reduce overhead by checking only every N nodes.
-    this.executionCheckCounter =
-      (this.executionCheckCounter + 1) & Interpreter.EXECUTION_CHECK_MASK;
-    if (this.executionCheckCounter !== 0) {
-      return;
+    if (!force) {
+      // Reduce overhead by checking only every N nodes.
+      this.executionCheckCounter =
+        (this.executionCheckCounter + 1) & Interpreter.EXECUTION_CHECK_MASK;
+      if (this.executionCheckCounter !== 0) {
+        return;
+      }
     }
     if (abortSignal?.aborted) {
       throw new InterpreterError("Execution aborted");
@@ -3105,6 +3107,27 @@ export class Interpreter {
         throw new ResourceExhaustedError("maxCpuTime", cpuTimeMs, maxCpuTime);
       }
     }
+  }
+
+  private withImmediateExecutionLimitCheck<T>(operation: () => T): T {
+    this.checkExecutionLimits(true);
+    const result = operation();
+    this.checkExecutionLimits(true);
+    return result;
+  }
+
+  private async withImmediateExecutionLimitCheckAsync<T>(operation: () => Promise<T>): Promise<T> {
+    this.checkExecutionLimits(true);
+    const result = await operation();
+    this.checkExecutionLimits(true);
+    return result;
+  }
+
+  private shouldRethrowExecutionControlError(error: unknown): boolean {
+    return (
+      error instanceof ResourceExhaustedError ||
+      (error instanceof InterpreterError && error.message === "Execution aborted")
+    );
   }
 
   /**
@@ -5334,10 +5357,14 @@ export class Interpreter {
         : this.executeSandboxFunction(tag, args, undefined);
     }
     if (tag instanceof HostFunctionValue) {
-      return tag.hostFunc(...args);
+      return isAsync
+        ? this.withImmediateExecutionLimitCheckAsync(async () => tag.hostFunc(...args))
+        : this.withImmediateExecutionLimitCheck(() => tag.hostFunc(...args));
     }
     if (typeof tag === "function") {
-      return tag(...args);
+      return isAsync
+        ? this.withImmediateExecutionLimitCheckAsync(async () => tag(...args))
+        : this.withImmediateExecutionLimitCheck(() => tag(...args));
     }
     throw new InterpreterError("Tag expression is not a function");
   }
@@ -6559,9 +6586,14 @@ export class Interpreter {
   ): any {
     try {
       const wrappedArgs = constructor.skipArgWrapping ? args : this.wrapArgsForHost(args, isAsync);
-      const result = Reflect.construct(constructor.hostFunc, wrappedArgs);
+      const result = this.withImmediateExecutionLimitCheck(() =>
+        Reflect.construct(constructor.hostFunc, wrappedArgs),
+      );
       return ReadOnlyProxy.wrap(result, constructor.name, this.securityOptions);
     } catch (error: any) {
+      if (this.shouldRethrowExecutionControlError(error)) {
+        throw error;
+      }
       throw new InterpreterError(
         this.formatHostError(`Constructor '${constructor.name}' threw error`, error),
       );
@@ -7742,7 +7774,7 @@ export class Interpreter {
 
       // Iterate using the iterator protocol
       while (true) {
-        const iterResult = iterator.next();
+        const iterResult = this.withImmediateExecutionLimitCheck(() => iterator.next());
         if (iterResult.done) {
           break;
         }
@@ -7791,7 +7823,7 @@ export class Interpreter {
         if (isControlFlowKind(result, "break")) {
           // Call iterator.return() to allow cleanup (e.g., finally blocks in generators)
           if (typeof iterator.return === "function") {
-            iterator.return();
+            this.withImmediateExecutionLimitCheck(() => iterator.return!());
           }
           // Labeled break targeting a different label - propagate
           if (result.label !== null && result.label !== myLabel) {
@@ -7802,7 +7834,7 @@ export class Interpreter {
         if (isControlFlowKind(result, "return")) {
           // Call iterator.return() to allow cleanup
           if (typeof iterator.return === "function") {
-            iterator.return();
+            this.withImmediateExecutionLimitCheck(() => iterator.return!());
           }
           return result;
         }
@@ -7813,7 +7845,7 @@ export class Interpreter {
           result.label !== myLabel
         ) {
           if (typeof iterator.return === "function") {
-            iterator.return();
+            this.withImmediateExecutionLimitCheck(() => iterator.return!());
           }
           return result;
         }
@@ -8639,9 +8671,12 @@ export class Interpreter {
 
       // Call the host function
       try {
-        const result = callee.hostFunc(...wrappedArgs);
+        const result = this.withImmediateExecutionLimitCheck(() => callee.hostFunc(...wrappedArgs));
         return this.wrapHostReturnValue(result, callee.name);
       } catch (error: any) {
+        if (this.shouldRethrowExecutionControlError(error)) {
+          throw error;
+        }
         // If rethrowErrors is true, propagate the error directly (used by generator.throw())
         if (callee.rethrowErrors) {
           throw error;
@@ -8655,7 +8690,9 @@ export class Interpreter {
     // Handle native JavaScript functions (e.g., bound class methods)
     if (typeof callee === "function") {
       const args = this.evaluateArguments(node.arguments);
-      return thisValue !== undefined ? callee.call(thisValue, ...args) : callee(...args);
+      return this.withImmediateExecutionLimitCheck(() =>
+        thisValue !== undefined ? callee.call(thisValue, ...args) : callee(...args),
+      );
     }
 
     if (callee instanceof ClassValue) {
@@ -9634,7 +9671,7 @@ export class Interpreter {
    * Wraps functions as HostFunctionValue so they can be called safely from the sandbox.
    */
   private getNativePropertyValue(object: any, property: string): any {
-    const value = (object as any)[property];
+    const value = this.withImmediateExecutionLimitCheck(() => (object as any)[property]);
     if (typeof value === "function") {
       if (this.isPrimitiveValue(object)) {
         const cache = this.getPrimitiveMethodEntries(object);
@@ -10181,12 +10218,14 @@ export class Interpreter {
       const wrappedArgs = callee.skipArgWrapping ? args : this.wrapArgsForHost(args, true);
 
       try {
-        const result = callee.hostFunc(...wrappedArgs);
         // If async host function, await the promise
         if (callee.isAsync) {
-          const resolved = await result;
+          const resolved = await this.withImmediateExecutionLimitCheckAsync(async () =>
+            callee.hostFunc(...wrappedArgs),
+          );
           return this.wrapHostReturnValue(resolved, callee.name);
         }
+        const result = this.withImmediateExecutionLimitCheck(() => callee.hostFunc(...wrappedArgs));
         const wrapped = this.wrapHostReturnValue(result, callee.name);
         // Wrap Promise results in RawValue to prevent auto-awaiting by async/await
         // This preserves Promise identity for chaining (e.g., Promise.resolve(1).then(...))
@@ -10195,6 +10234,9 @@ export class Interpreter {
         }
         return wrapped;
       } catch (error: any) {
+        if (this.shouldRethrowExecutionControlError(error)) {
+          throw error;
+        }
         // If rethrowErrors is true, propagate the error directly (used by generator.throw())
         if (callee.rethrowErrors) {
           throw error;
@@ -10209,8 +10251,9 @@ export class Interpreter {
     if (typeof callee === "function") {
       const args = await this.evaluateArgumentsAsync(node.arguments);
       const wrappedArgs = this.wrapArgsForHost(args, true);
-      const result =
-        thisValue !== undefined ? callee.call(thisValue, ...wrappedArgs) : callee(...wrappedArgs);
+      const result = this.withImmediateExecutionLimitCheck(() =>
+        thisValue !== undefined ? callee.call(thisValue, ...wrappedArgs) : callee(...wrappedArgs),
+      );
       // Wrap Promise results in RawValue to prevent auto-awaiting
       if (result instanceof Promise) {
         return new RawValue(result);
@@ -11143,8 +11186,10 @@ export class Interpreter {
       // Iterate using the iterator protocol
       while (true) {
         const iterResult = shouldAwait
-          ? await (iterator as AsyncIterator<any>).next()
-          : (iterator as Iterator<any>).next();
+          ? await this.withImmediateExecutionLimitCheckAsync(async () =>
+              (iterator as AsyncIterator<any>).next(),
+            )
+          : this.withImmediateExecutionLimitCheck(() => (iterator as Iterator<any>).next());
         if (iterResult.done) {
           break;
         }
@@ -11188,9 +11233,11 @@ export class Interpreter {
           // Call iterator.return() to allow cleanup (e.g., finally blocks in generators)
           if (typeof iterator.return === "function") {
             if (shouldAwait) {
-              await (iterator as AsyncIterator<any>).return?.();
+              await this.withImmediateExecutionLimitCheckAsync(async () =>
+                (iterator as AsyncIterator<any>).return?.(),
+              );
             } else {
-              (iterator as Iterator<any>).return?.();
+              this.withImmediateExecutionLimitCheck(() => (iterator as Iterator<any>).return?.());
             }
           }
           // Labeled break targeting a different label - propagate
@@ -11203,9 +11250,11 @@ export class Interpreter {
           // Call iterator.return() to allow cleanup
           if (typeof iterator.return === "function") {
             if (shouldAwait) {
-              await (iterator as AsyncIterator<any>).return?.();
+              await this.withImmediateExecutionLimitCheckAsync(async () =>
+                (iterator as AsyncIterator<any>).return?.(),
+              );
             } else {
-              (iterator as Iterator<any>).return?.();
+              this.withImmediateExecutionLimitCheck(() => (iterator as Iterator<any>).return?.());
             }
           }
           return result;
@@ -11218,9 +11267,11 @@ export class Interpreter {
         ) {
           if (typeof iterator.return === "function") {
             if (shouldAwait) {
-              await (iterator as AsyncIterator<any>).return?.();
+              await this.withImmediateExecutionLimitCheckAsync(async () =>
+                (iterator as AsyncIterator<any>).return?.(),
+              );
             } else {
-              (iterator as Iterator<any>).return?.();
+              this.withImmediateExecutionLimitCheck(() => (iterator as Iterator<any>).return?.());
             }
           }
           return result;

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -31,7 +31,7 @@ import {
   isEcmaBuiltinInstancePropertyAvailable,
   type EcmaPresetVersion,
 } from "./ecmascript-builtins";
-import { InterpreterError, SecurityError, ErrorCode } from "./errors";
+import { ExecutionAbortedError, InterpreterError, SecurityError, ErrorCode } from "./errors";
 import { ModuleSystem } from "./modules";
 import {
   ReadOnlyProxy,
@@ -2798,7 +2798,7 @@ export class Interpreter {
    */
   private async acquireEvaluationMutex(signal?: AbortSignal): Promise<() => void> {
     if (signal?.aborted) {
-      throw new InterpreterError("Execution aborted");
+      throw new ExecutionAbortedError();
     }
 
     const previousQueue = this.evaluationMutexQueue;
@@ -2824,7 +2824,7 @@ export class Interpreter {
       let onAbort: (() => void) | undefined;
       try {
         await new Promise<void>((resolve, reject) => {
-          onAbort = () => reject(new InterpreterError("Execution aborted"));
+          onAbort = () => reject(new ExecutionAbortedError());
           signal.addEventListener("abort", onAbort, { once: true });
           previousQueue.then(resolve, reject);
         });
@@ -3098,7 +3098,7 @@ export class Interpreter {
       }
     }
     if (abortSignal?.aborted) {
-      throw new InterpreterError("Execution aborted");
+      throw new ExecutionAbortedError();
     }
 
     if (maxCpuTime !== undefined) {
@@ -3124,10 +3124,7 @@ export class Interpreter {
   }
 
   private shouldRethrowExecutionControlError(error: unknown): boolean {
-    return (
-      error instanceof ResourceExhaustedError ||
-      (error instanceof InterpreterError && error.message === "Execution aborted")
-    );
+    return error instanceof ResourceExhaustedError || error instanceof ExecutionAbortedError;
   }
 
   /**
@@ -3445,7 +3442,7 @@ export class Interpreter {
       this.setCurrentAbortSignal(options?.signal);
       const abortSignal = this.getCurrentAbortSignal();
       if (abortSignal?.aborted) {
-        throw new InterpreterError("Execution aborted");
+        throw new ExecutionAbortedError();
       }
 
       const ast = this.parseAndValidate(input, options);
@@ -3970,7 +3967,7 @@ export class Interpreter {
       this.setCurrentAbortSignal(options.signal);
       const abortSignal = this.getCurrentAbortSignal();
       if (abortSignal?.aborted) {
-        throw new InterpreterError("Execution aborted");
+        throw new ExecutionAbortedError();
       }
 
       const ast = this.parseModuleAndValidate(code, options);
@@ -13956,5 +13953,5 @@ export class Interpreter {
   }
 }
 
-// Re-export InterpreterError for use in tests and public API
-export { InterpreterError };
+// Re-export interpreter-facing error types for use in tests and public API
+export { ExecutionAbortedError, InterpreterError };

--- a/test/execution-control.test.ts
+++ b/test/execution-control.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from "bun:test";
 
-import { InterpreterError } from "../src/errors";
+import { ExecutionAbortedError, InterpreterError } from "../src/errors";
 import { Interpreter } from "../src/interpreter";
 
 describe("Execution Control", () => {
@@ -512,6 +512,7 @@ describe("Execution Control", () => {
           });
           expect().fail("Expected error");
         } catch (e: any) {
+          expect(e).toBeInstanceOf(ExecutionAbortedError);
           expect(e.message).toBe("Execution aborted");
         }
 

--- a/test/execution-control.test.ts
+++ b/test/execution-control.test.ts
@@ -473,6 +473,31 @@ describe("Execution Control", () => {
         ).rejects.toThrow("Execution aborted");
       });
 
+      test("should abort immediately after a host call aborts the active signal", async () => {
+        const controller = new AbortController();
+        const interpreter = new Interpreter({
+          globals: {
+            abortNow: () => {
+              controller.abort();
+              return "aborted";
+            },
+          },
+        });
+
+        await expect(
+          interpreter.evaluateAsync(
+            `
+              async function run() {
+                abortNow();
+                return 1;
+              }
+              run()
+            `,
+            { signal: controller.signal },
+          ),
+        ).rejects.toThrow("Execution aborted");
+      });
+
       test("signal should be per-call", async () => {
         const interpreter = new Interpreter();
         const controller1 = new AbortController();

--- a/test/resource-tracker.test.ts
+++ b/test/resource-tracker.test.ts
@@ -137,6 +137,40 @@ describe("Resource Tracking", () => {
           }
         });
 
+        test("should abort within a single host call when maxCpuTime is exceeded", () => {
+          let currentTime = 0;
+          const interpreter = new Interpreter({
+            ...ES2022,
+            resourceTracking: true,
+            globals: {
+              burnCpuTime: () => {
+                currentTime += 20;
+                return "done";
+              },
+            },
+          });
+          interpreter.setResourceLimit("maxCpuTime", 15);
+
+          const originalNow = Object.getOwnPropertyDescriptor(performance, "now");
+
+          Object.defineProperty(performance, "now", {
+            configurable: true,
+            value: () => currentTime,
+          });
+
+          try {
+            expect(() => {
+              interpreter.evaluate(`
+                burnCpuTime();
+              `);
+            }).toThrow(ResourceExhaustedError);
+          } finally {
+            if (originalNow) {
+              Object.defineProperty(performance, "now", originalNow);
+            }
+          }
+        });
+
         test("should throw when maxTotalIterations exceeded", () => {
           const interpreter = new Interpreter({
             ...ES2022,


### PR DESCRIPTION
## Summary

Tighten execution-limit responsiveness around delegated interpreter work.

- force execution-limit checks immediately before and after heavyweight delegated operations such as host/native calls, constructors, tagged template invocation, native property reads, and iterator delegation
- preserve the existing low-overhead sampled checks for ordinary AST walking
- add regressions proving a single host call now aborts the active evaluation immediately when it exceeds `maxCpuTime` or aborts the active `AbortSignal`
- include a patch changeset

## Why

Issue #186 identified that execution-limit checks were only sampled every 256 node visits. That kept normal evaluation cheap, but it also meant a single coarse-grained host/native operation could consume noticeable CPU time or trip cancellation without the interpreter noticing until much later, and sometimes not until after the current evaluation had already completed.

## Root Cause

The interpreter only called `checkExecutionLimits()` on the sampled AST-walk path. Heavy work happening inside one delegated native operation could therefore hide between checkpoints.

## Impact

- `maxCpuTime` enforcement is more responsive around delegated native work
- async cancellation via `AbortSignal` is observed immediately after heavyweight delegated operations complete
- normal AST evaluation keeps the existing sampled-check behavior, so this does not turn every node visit into a forced limit check

## Validation

- `bun run fmt`
- `bun run lint:fix`
- `bun test`
- `bun run typecheck`

Closes #186