### PR TITLE
[codex] clarify cumulative memory tracking as allocation budget

### DIFF
--- a/.changeset/fair-cougars-poke.md
+++ b/.changeset/fair-cougars-poke.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Clarify cumulative memory tracking as an allocation budget and add explicit `allocationBytes` / `maxAllocationBytes` aliases while keeping the legacy memory names for compatibility.

--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ allowed (`myHostFunc(...)`), but dangerous/introspective function properties are
 Use multiple controls together:
 
 - Per-run limits (`loops`, `callDepth`, `memoryBytes`)
-- Total limits for cumulative usage (`limits.total`)
+- Total limits for cumulative usage (`limits.total`), including the explicit `allocationBytes` budget alias
 - Async timeout (`timeoutMs`)
 - Optional async cancellation (`AbortSignal`)
 
@@ -539,7 +539,8 @@ and can be disabled/configured.
 ### How can I inspect resource usage?
 
 Use `result: "full"` per call for execution stats, and `sandbox.resources()` for cumulative stats when
-resource tracking is enabled.
+resource tracking is enabled. For memory, `allocationBytes` is the explicit cumulative-allocation field;
+`memoryBytes` remains as a backwards-compatible alias.
 
 ## Limitations
 

--- a/docs/INTERNAL_CLASSES.md
+++ b/docs/INTERNAL_CLASSES.md
@@ -85,14 +85,14 @@ import { ResourceTracker } from "nookjs";
 
 const tracker = new ResourceTracker({
   limits: {
-    maxTotalMemory: 100 * 1024 * 1024,
+    maxAllocationBytes: 100 * 1024 * 1024,
     maxTotalIterations: 1_000_000,
   },
   historySize: 100,
 });
 
 const stats = tracker.getStats();
-console.log(stats.memoryBytes);
+console.log(stats.allocationBytes);
 ```
 
 ## Errors

--- a/docs/RESOURCE_ATTRIBUTION.md
+++ b/docs/RESOURCE_ATTRIBUTION.md
@@ -22,7 +22,7 @@ const sandbox = createSandbox({
   limits: {
     total: {
       evaluations: 100,
-      memoryBytes: 50 * 1024 * 1024,
+      allocationBytes: 50 * 1024 * 1024,
     },
   },
 });
@@ -46,7 +46,7 @@ const sandbox = createSandbox({
   env: "es2022",
   limits: {
     total: {
-      memoryBytes: 100 * 1024 * 1024,
+      allocationBytes: 100 * 1024 * 1024,
       iterations: 1_000_000,
       functionCalls: 10_000,
       evaluations: 100,
@@ -64,7 +64,7 @@ try {
 }
 
 const stats = sandbox.resources();
-console.log(`Memory used: ${stats?.memoryBytes} bytes`);
+console.log(`Allocated bytes so far: ${stats?.allocationBytes} bytes`);
 ```
 
 For low-level resource APIs, see [Internal Classes](INTERNAL_CLASSES.md).
@@ -78,7 +78,7 @@ import { ResourceTracker, ResourceExhaustedError } from "nookjs";
 
 const tracker = new ResourceTracker({
   limits: {
-    maxTotalMemory: 100 * 1024 * 1024,
+    maxAllocationBytes: 100 * 1024 * 1024,
     maxTotalIterations: 1000000,
     maxFunctionCalls: 10000,
     maxCpuTime: 30000,
@@ -100,8 +100,8 @@ if (tracker.isExhausted()) {
 tracker.reset();
 
 // Get/set individual limits
-tracker.setLimit("maxTotalMemory", 200 * 1024 * 1024);
-const memLimit = tracker.getLimit("maxTotalMemory");
+tracker.setLimit("maxAllocationBytes", 200 * 1024 * 1024);
+const memLimit = tracker.getLimit("maxAllocationBytes");
 
 // Get evaluation history
 const history = tracker.getHistory();
@@ -115,7 +115,8 @@ const history = tracker.getHistory();
 
 ```typescript
 type ResourceLimits = {
-  maxTotalMemory?: number; // bytes (cumulative)
+  maxAllocationBytes?: number; // bytes (cumulative allocation budget)
+  maxTotalMemory?: number; // legacy alias for maxAllocationBytes
   maxTotalIterations?: number; // loop iterations (cumulative)
   maxFunctionCalls?: number; // function invocations (cumulative)
   maxCpuTime?: number; // milliseconds (best-effort wall-clock enforcement)
@@ -127,7 +128,8 @@ type ResourceLimits = {
 
 ```typescript
 type ResourceStats = {
-  memoryBytes: number; // current estimated memory
+  allocationBytes: number; // cumulative allocation estimate across evaluations
+  memoryBytes: number; // legacy alias for allocationBytes
   iterations: number; // total loop iterations
   functionCalls: number; // total function calls
   cpuTimeMs: number; // cumulative CPU time
@@ -147,6 +149,9 @@ type ResourceStats = {
   };
 };
 ```
+
+`memoryBytes` and `maxTotalMemory` remain available for compatibility, but they describe cumulative
+allocation accounting rather than retained/live memory. A retained-memory quota is not currently exposed.
 
 ### ResourceHistoryEntry
 
@@ -183,7 +188,7 @@ function createPluginSandbox(pluginId: string, memoryLimit: number) {
     globals: getPluginGlobals(pluginId),
     limits: {
       total: {
-        memoryBytes: memoryLimit,
+        allocationBytes: memoryLimit,
         evaluations: 1000,
       },
     },
@@ -197,7 +202,7 @@ const plugins = {
 
 await plugins.payment.run(paymentCode);
 const stats = plugins.payment.resources();
-console.log(`Payment plugin memory: ${stats?.memoryBytes} bytes`);
+console.log(`Payment plugin allocation budget used: ${stats?.allocationBytes} bytes`);
 ```
 
 ### Educational Platforms

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -470,7 +470,7 @@ const sandbox = createSandbox({
   env: "es2022",
   limits: {
     total: {
-      memoryBytes: 100 * 1024 * 1024, // 100 MB
+      allocationBytes: 100 * 1024 * 1024, // 100 MB cumulative allocation budget
       iterations: 1_000_000, // 1M iterations
       functionCalls: 10_000, // 10K calls
       evaluations: 100, // 100 evaluations
@@ -491,6 +491,7 @@ const stats = sandbox.resources();
 console.log(stats);
 /*
 {
+  allocationBytes: 24576,
   memoryBytes: 24576,
   iterations: 10000,
   functionCalls: 3,
@@ -500,6 +501,7 @@ console.log(stats);
   largestEvaluation: { memory: 16384, iterations: 10000 },
   isExhausted: false,
   limitStatus: {
+    maxAllocationBytes: { used: 24576, limit: 104857600, remaining: 104833024 },
     maxTotalMemory: { used: 24576, limit: 104857600, remaining: 104833024 },
     maxTotalIterations: { used: 10000, limit: 1000000, remaining: 990000 },
     ...
@@ -517,7 +519,8 @@ internal `Interpreter` class. See [Internal Classes](INTERNAL_CLASSES.md).
 
 ```typescript
 type ResourceLimits = {
-  maxTotalMemory?: number; // bytes
+  maxAllocationBytes?: number; // bytes (cumulative allocation budget)
+  maxTotalMemory?: number; // legacy alias for maxAllocationBytes
   maxTotalIterations?: number; // loop iterations
   maxFunctionCalls?: number; // total function invocations
   maxCpuTime?: number; // milliseconds (best-effort wall-clock enforcement)
@@ -529,7 +532,8 @@ type ResourceLimits = {
 
 ```typescript
 type ResourceStats = {
-  memoryBytes: number; // current estimated memory
+  allocationBytes: number; // cumulative allocation estimate across evaluations
+  memoryBytes: number; // legacy alias for allocationBytes
   iterations: number; // total loop iterations
   functionCalls: number; // total function calls
   cpuTimeMs: number; // cumulative CPU time (best-effort)
@@ -549,6 +553,9 @@ type ResourceStats = {
   };
 };
 ```
+
+Integrated memory tracking is allocation-based. `memoryBytes` / `allocationBytes` do not represent a
+retained/live heap measurement after garbage collection or sandbox resets.
 
 ### Error Handling
 

--- a/docs/SIMPLIFIED_API.md
+++ b/docs/SIMPLIFIED_API.md
@@ -27,7 +27,7 @@ const sandbox = createSandbox({
   },
   limits: {
     perRun: { loops: 1_000_000, callDepth: 200 },
-    total: { memoryBytes: 50 * 1024 * 1024 },
+    total: { allocationBytes: 50 * 1024 * 1024 },
   },
   policy: { errors: "safe" },
 });
@@ -105,10 +105,14 @@ const sandbox = createSandbox({
   env: "es2022",
   limits: {
     perRun: { loops: 100_000, callDepth: 200, memoryBytes: 2_000_000 },
-    total: { evaluations: 100, memoryBytes: 50_000_000 },
+    total: { evaluations: 100, allocationBytes: 50_000_000 },
   },
 });
 ```
+
+`limits.total` tracks cumulative allocation estimates across evaluations, not retained/live memory.
+Use `allocationBytes` for the explicit name. `memoryBytes` remains supported as a backwards-compatible
+alias for the same cumulative budget.
 
 ### `timeoutMs`
 

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -2480,6 +2480,7 @@ export type ExecutionStats = {
  */
 export type ResourceLimits = {
   maxTotalMemory?: number;
+  maxAllocationBytes?: number;
   maxTotalIterations?: number;
   maxFunctionCalls?: number;
   maxCpuTime?: number;
@@ -2490,6 +2491,7 @@ export type ResourceLimits = {
  * Resource statistics from integrated tracking
  */
 export type ResourceStats = {
+  allocationBytes: number;
   memoryBytes: number;
   iterations: number;
   functionCalls: number;

--- a/src/resource-tracker.ts
+++ b/src/resource-tracker.ts
@@ -2,6 +2,7 @@ import { InterpreterError } from "./errors";
 
 export type ResourceLimits = {
   maxTotalMemory?: number;
+  maxAllocationBytes?: number;
   maxTotalIterations?: number;
   maxFunctionCalls?: number;
   maxCpuTime?: number;
@@ -9,6 +10,7 @@ export type ResourceLimits = {
 };
 
 export type ResourceStats = {
+  allocationBytes: number;
   memoryBytes: number;
   iterations: number;
   functionCalls: number;
@@ -69,6 +71,7 @@ export class ResourceTracker {
   constructor(options?: { limits?: ResourceLimits; historySize?: number }) {
     if (options?.limits) {
       this.limits = { ...options.limits };
+      this.syncMemoryLimitAliases();
     }
     this.historySize = options?.historySize ?? 100;
   }
@@ -83,6 +86,7 @@ export class ResourceTracker {
       let used = 0;
       switch (key) {
         case "maxTotalMemory":
+        case "maxAllocationBytes":
           used = this.cumulativeMemory;
           break;
         case "maxTotalIterations":
@@ -107,6 +111,7 @@ export class ResourceTracker {
     }
 
     return {
+      allocationBytes: this.cumulativeMemory,
       memoryBytes: this.cumulativeMemory,
       iterations: this.cumulativeIterations,
       functionCalls: this.cumulativeFunctionCalls,
@@ -157,6 +162,7 @@ export class ResourceTracker {
 
   setLimit(key: keyof ResourceLimits, value: number): void {
     this.limits[key] = value;
+    this.syncMemoryLimitAliases();
   }
 
   beginEvaluation(): void {
@@ -227,6 +233,17 @@ export class ResourceTracker {
         this.exhaustedLimit = key;
         return;
       }
+    }
+  }
+
+  private syncMemoryLimitAliases(): void {
+    const allocationLimit = this.limits.maxAllocationBytes;
+    const totalMemoryLimit = this.limits.maxTotalMemory;
+
+    if (allocationLimit !== undefined) {
+      this.limits.maxTotalMemory = allocationLimit;
+    } else if (totalMemoryLimit !== undefined) {
+      this.limits.maxAllocationBytes = totalMemoryLimit;
     }
   }
 }

--- a/src/resource-tracker.ts
+++ b/src/resource-tracker.ts
@@ -58,6 +58,7 @@ export class ResourceTracker {
   private historySize: number;
   private history: ResourceHistoryEntry[] = [];
   private evaluationNumber = 0;
+  private preferredMemoryLimitKey: "maxAllocationBytes" | "maxTotalMemory" = "maxAllocationBytes";
 
   private cumulativeMemory = 0;
   private cumulativeIterations = 0;
@@ -70,8 +71,14 @@ export class ResourceTracker {
 
   constructor(options?: { limits?: ResourceLimits; historySize?: number }) {
     if (options?.limits) {
+      this.assertMemoryLimitAliasesMatch(
+        options.limits.maxAllocationBytes,
+        options.limits.maxTotalMemory,
+      );
       this.limits = { ...options.limits };
-      this.syncMemoryLimitAliases();
+      this.preferredMemoryLimitKey =
+        options.limits.maxAllocationBytes !== undefined ? "maxAllocationBytes" : "maxTotalMemory";
+      this.syncMemoryLimitAliases(this.preferredMemoryLimitKey);
     }
     this.historySize = options?.historySize ?? 100;
   }
@@ -162,7 +169,10 @@ export class ResourceTracker {
 
   setLimit(key: keyof ResourceLimits, value: number): void {
     this.limits[key] = value;
-    this.syncMemoryLimitAliases();
+    if (key === "maxAllocationBytes" || key === "maxTotalMemory") {
+      this.preferredMemoryLimitKey = key;
+      this.syncMemoryLimitAliases(key);
+    }
   }
 
   beginEvaluation(): void {
@@ -227,7 +237,19 @@ export class ResourceTracker {
   private checkLimits(): void {
     const stats = this.getStats();
 
+    const preferredMemoryLimitStatus = stats.limitStatus[this.preferredMemoryLimitKey];
+    if (
+      preferredMemoryLimitStatus &&
+      preferredMemoryLimitStatus.used >= preferredMemoryLimitStatus.limit
+    ) {
+      this.exhaustedLimit = this.preferredMemoryLimitKey;
+      return;
+    }
+
     for (const key of Object.keys(stats.limitStatus) as (keyof ResourceLimits)[]) {
+      if (key === "maxAllocationBytes" || key === "maxTotalMemory") {
+        continue;
+      }
       const status = stats.limitStatus[key];
       if (status && status.used >= status.limit) {
         this.exhaustedLimit = key;
@@ -236,14 +258,28 @@ export class ResourceTracker {
     }
   }
 
-  private syncMemoryLimitAliases(): void {
+  private syncMemoryLimitAliases(lastWritten?: "maxAllocationBytes" | "maxTotalMemory"): void {
     const allocationLimit = this.limits.maxAllocationBytes;
     const totalMemoryLimit = this.limits.maxTotalMemory;
 
-    if (allocationLimit !== undefined) {
+    if (lastWritten === "maxAllocationBytes" && allocationLimit !== undefined) {
+      this.limits.maxTotalMemory = allocationLimit;
+    } else if (lastWritten === "maxTotalMemory" && totalMemoryLimit !== undefined) {
+      this.limits.maxAllocationBytes = totalMemoryLimit;
+    } else if (allocationLimit !== undefined) {
       this.limits.maxTotalMemory = allocationLimit;
     } else if (totalMemoryLimit !== undefined) {
       this.limits.maxAllocationBytes = totalMemoryLimit;
+    }
+  }
+
+  private assertMemoryLimitAliasesMatch(allocationLimit?: number, totalMemoryLimit?: number): void {
+    if (
+      allocationLimit !== undefined &&
+      totalMemoryLimit !== undefined &&
+      allocationLimit !== totalMemoryLimit
+    ) {
+      throw new Error("maxAllocationBytes and maxTotalMemory must match");
     }
   }
 }

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -584,9 +584,10 @@ const applyTotalLimits = (interpreter: Interpreter, limits?: TotalLimits): void 
     throw new Error("limits.total.memoryBytes and limits.total.allocationBytes must match");
   }
 
-  const allocationBytes = limits.allocationBytes ?? limits.memoryBytes;
-  if (allocationBytes !== undefined) {
-    interpreter.setResourceLimit("maxAllocationBytes", allocationBytes);
+  if (limits.allocationBytes !== undefined) {
+    interpreter.setResourceLimit("maxAllocationBytes", limits.allocationBytes);
+  } else if (limits.memoryBytes !== undefined) {
+    interpreter.setResourceLimit("maxTotalMemory", limits.memoryBytes);
   }
   if (limits.iterations !== undefined) {
     interpreter.setResourceLimit("maxTotalIterations", limits.iterations);

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -108,6 +108,7 @@ export interface RunLimits {
 }
 
 export interface TotalLimits {
+  readonly allocationBytes?: number;
   readonly memoryBytes?: number;
   readonly iterations?: number;
   readonly functionCalls?: number;
@@ -334,6 +335,7 @@ const hasTotalLimits = (limits?: TotalLimits): boolean => {
   }
 
   return (
+    limits.allocationBytes !== undefined ||
     limits.memoryBytes !== undefined ||
     limits.iterations !== undefined ||
     limits.functionCalls !== undefined ||
@@ -574,8 +576,17 @@ const applyTotalLimits = (interpreter: Interpreter, limits?: TotalLimits): void 
     return;
   }
 
-  if (limits.memoryBytes !== undefined) {
-    interpreter.setResourceLimit("maxTotalMemory", limits.memoryBytes);
+  if (
+    limits.allocationBytes !== undefined &&
+    limits.memoryBytes !== undefined &&
+    limits.allocationBytes !== limits.memoryBytes
+  ) {
+    throw new Error("limits.total.memoryBytes and limits.total.allocationBytes must match");
+  }
+
+  const allocationBytes = limits.allocationBytes ?? limits.memoryBytes;
+  if (allocationBytes !== undefined) {
+    interpreter.setResourceLimit("maxAllocationBytes", allocationBytes);
   }
   if (limits.iterations !== undefined) {
     interpreter.setResourceLimit("maxTotalIterations", limits.iterations);

--- a/test/resource-tracker.test.ts
+++ b/test/resource-tracker.test.ts
@@ -310,6 +310,24 @@ describe("Resource Tracking", () => {
             remaining: 4,
           });
         });
+
+        test("should preserve the configured memory alias when the budget is exhausted", () => {
+          const allocationTracker = new ResourceTracker();
+          allocationTracker.setLimit("maxAllocationBytes", 5);
+
+          allocationTracker.beginEvaluation();
+          allocationTracker.endEvaluation(5, 0, 0, 0);
+
+          expect(allocationTracker.getExhaustedLimit()).toBe("maxAllocationBytes");
+
+          const totalMemoryTracker = new ResourceTracker();
+          totalMemoryTracker.setLimit("maxTotalMemory", 5);
+
+          totalMemoryTracker.beginEvaluation();
+          totalMemoryTracker.endEvaluation(5, 0, 0, 0);
+
+          expect(totalMemoryTracker.getExhaustedLimit()).toBe("maxTotalMemory");
+        });
       });
 
       describe("reset functionality", () => {
@@ -412,6 +430,20 @@ describe("Resource Tracking", () => {
           interpreter.setResourceLimit("maxTotalMemory", 2048);
 
           expect(interpreter.getResourceLimit("maxTotalMemory")).toBe(2048);
+        });
+
+        test("should let the last-written memory alias win", () => {
+          const tracker = new ResourceTracker();
+          tracker.setLimit("maxAllocationBytes", 100);
+          tracker.setLimit("maxTotalMemory", 200);
+
+          expect(tracker.getLimit("maxAllocationBytes")).toBe(200);
+          expect(tracker.getLimit("maxTotalMemory")).toBe(200);
+
+          tracker.setLimit("maxAllocationBytes", 300);
+
+          expect(tracker.getLimit("maxAllocationBytes")).toBe(300);
+          expect(tracker.getLimit("maxTotalMemory")).toBe(300);
         });
 
         test("should update limits after construction", () => {
@@ -622,6 +654,15 @@ describe("Resource Tracking", () => {
             limits: { maxEvaluations: 10 },
           });
           expect(tracker.getLimit("maxEvaluations")).toBe(10);
+        });
+
+        test("should reject conflicting memory limit aliases at construction", () => {
+          expect(
+            () =>
+              new ResourceTracker({
+                limits: { maxAllocationBytes: 100, maxTotalMemory: 200 },
+              }),
+          ).toThrow("maxAllocationBytes and maxTotalMemory must match");
         });
 
         test("should create tracker with history size", () => {

--- a/test/resource-tracker.test.ts
+++ b/test/resource-tracker.test.ts
@@ -31,6 +31,7 @@ describe("Resource Tracking", () => {
 
           const stats = interpreter.getResourceStats();
           expect(stats.evaluations).toBe(1);
+          expect(stats.allocationBytes).toBe(stats.memoryBytes);
         });
 
         test("should track cumulative loop iterations", () => {
@@ -290,6 +291,23 @@ describe("Resource Tracking", () => {
             used: 2,
             limit: 10,
             remaining: 8,
+          });
+        });
+
+        test("should allow explicit allocation budget aliases", () => {
+          const tracker = new ResourceTracker();
+          tracker.setLimit("maxAllocationBytes", 10);
+
+          tracker.beginEvaluation();
+          tracker.endEvaluation(6, 0, 0, 0);
+
+          const stats = tracker.getStats();
+          expect(stats.memoryBytes).toBe(6);
+          expect(stats.allocationBytes).toBe(6);
+          expect(stats.limitStatus.maxAllocationBytes).toEqual({
+            used: 6,
+            limit: 10,
+            remaining: 4,
           });
         });
       });

--- a/test/sandbox-api.test.ts
+++ b/test/sandbox-api.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test";
 
+import { ResourceExhaustedError } from "../src";
 import { createSandbox, parse, run } from "../src/sandbox";
 
 describe("Simplified API", () => {
@@ -629,6 +630,39 @@ describe("Simplified API", () => {
         limits: { total: { memoryBytes: 1, allocationBytes: 2 } },
       }),
     ).toThrow("limits.total.memoryBytes and limits.total.allocationBytes must match");
+  });
+
+  it("should preserve the legacy memory resourceType for memoryBytes total limits", () => {
+    const sandbox = createSandbox({
+      env: "es2022",
+      limits: { total: { memoryBytes: 1 } },
+    });
+
+    sandbox.runSync("const obj = { value: 1 }; obj;");
+
+    try {
+      sandbox.runSync("const second = { value: 2 }; second;");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ResourceExhaustedError);
+      expect((error as ResourceExhaustedError).resourceType).toBe("maxTotalMemory");
+    }
+  });
+
+  it("should use the explicit allocation resourceType for allocationBytes total limits", () => {
+    const sandbox = createSandbox({
+      env: "es2022",
+      limits: { total: { allocationBytes: 1 } },
+    });
+
+    sandbox.runSync("const obj = { value: 1 }; obj;");
+
+    try {
+      sandbox.runSync("const second = { value: 2 }; second;");
+      expect.unreachable("Expected allocationBytes total limit to be exceeded");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ResourceExhaustedError);
+      expect((error as ResourceExhaustedError).resourceType).toBe("maxAllocationBytes");
+    }
   });
 
   it("resources() should return undefined when tracking is disabled", () => {

--- a/test/sandbox-api.test.ts
+++ b/test/sandbox-api.test.ts
@@ -610,6 +610,27 @@ describe("Simplified API", () => {
     expect(() => sandbox.runSync("2 + 2")).toThrow("Resource limit exceeded");
   });
 
+  it("should accept allocationBytes as the explicit cumulative memory budget alias", () => {
+    const sandbox = createSandbox({
+      env: "es2022",
+      limits: { total: { allocationBytes: 1_000_000 } },
+    });
+
+    sandbox.runSync("const obj = {}; for (let i = 0; i < 100; i++) obj['key' + i] = i;");
+
+    const resources = sandbox.resources();
+    expect(resources?.allocationBytes).toBe(resources?.memoryBytes);
+  });
+
+  it("should reject conflicting cumulative memory aliases", () => {
+    expect(() =>
+      createSandbox({
+        env: "es2022",
+        limits: { total: { memoryBytes: 1, allocationBytes: 2 } },
+      }),
+    ).toThrow("limits.total.memoryBytes and limits.total.allocationBytes must match");
+  });
+
   it("resources() should return undefined when tracking is disabled", () => {
     const sandbox = createSandbox({ env: "es2022" });
 

--- a/test/sandbox-types.ts
+++ b/test/sandbox-types.ts
@@ -26,3 +26,12 @@ void ({} as AssertSandboxValue);
 void ({} as AssertSandboxFull);
 void ({} as AssertOneOffValue);
 void ({} as AssertOneOffFull);
+
+createSandbox({
+  env: "es2022",
+  limits: {
+    total: {
+      allocationBytes: 1024,
+    },
+  },
+});


### PR DESCRIPTION
## Summary

This PR clarifies that NookJS's integrated `memoryBytes` total limit is a cumulative allocation budget, not a retained/live-memory ceiling.

It introduces explicit `allocationBytes` and `maxAllocationBytes` aliases across the simplified sandbox API and `ResourceTracker`, while preserving the legacy `memoryBytes` and `maxTotalMemory` names for compatibility.

## Why

Issue #187 identified a semantic mismatch between the public naming and the implementation. `ResourceTracker.endEvaluation()` adds each evaluation's allocation estimate into a cumulative counter, so long-lived sandboxes were already enforcing an allocation budget even though the API surface still sounded like a retained-memory limit.

Rather than pretending the interpreter currently measures retained/live memory, this change makes the existing behavior explicit and documents the limitation directly.

## Changes

- add `limits.total.allocationBytes` as the explicit cumulative allocation-budget alias
- add `maxAllocationBytes` and `ResourceStats.allocationBytes` to `ResourceTracker`
- keep `memoryBytes` and `maxTotalMemory` as backwards-compatible aliases
- reject conflicting `memoryBytes` and `allocationBytes` values in sandbox configuration
- update README and resource/security docs to describe the allocation-based semantics
- add regression coverage for the alias behavior and the clarified cumulative accounting

## Impact

Embedders can now configure and read cumulative allocation budgets with explicit terminology without breaking existing integrations. The docs also now state clearly that retained/live-memory quotas are not currently exposed.

## Validation

- `bun run fmt`
- `bun run lint:fix`
- `bun run typecheck`
- `bun test test/resource-tracker.test.ts test/sandbox-api.test.ts`
- `bun test`

Closes #187
