### PR TITLE
fix(modules): canonicalize import.meta.url for relative module paths

### DIFF
--- a/.changeset/import-meta-url-relative-paths.md
+++ b/.changeset/import-meta-url-relative-paths.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Allow resolver's `getImportMeta` to provide a canonical `url` for relative module paths. When a resolver returns a relative `path` (e.g. `"dep.js"`) and its `getImportMeta` hook returns a `url` field containing a valid absolute URL, that URL is used as `import.meta.url` instead of the misleading `file:///dep.js` fallback. Absolute paths and URL-scheme paths retain their existing auto-generated URLs and are not affected.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -3994,9 +3994,18 @@ export class Interpreter {
    * @param importMetaExtensions - Additional resolver-provided import.meta properties
    * @returns The module's exported values
    */
-  private createImportMetaUrl(path: string): string {
+  private createImportMetaUrl(path: string, resolverUrl?: unknown): string {
     if (/^[A-Za-z][A-Za-z\d+.-]*:/.test(path)) {
       return path;
+    }
+
+    // For relative paths, prefer a canonical URL provided by the resolver.
+    if (!path.startsWith("/") && typeof resolverUrl === "string") {
+      try {
+        return new URL(resolverUrl).href;
+      } catch {
+        // Fall through to default behavior
+      }
     }
 
     try {
@@ -4011,7 +4020,7 @@ export class Interpreter {
     importMetaExtensions?: Record<string, any>,
   ): Record<string, any> {
     const baseMeta: Record<string, any> = {
-      url: this.createImportMetaUrl(path),
+      url: this.createImportMetaUrl(path, importMetaExtensions?.url),
     };
 
     if (importMetaExtensions && typeof importMetaExtensions === "object") {

--- a/test/modules.test.ts
+++ b/test/modules.test.ts
@@ -4629,5 +4629,99 @@ describe("Module System", () => {
         ),
       ).rejects.toThrow("read-only");
     });
+
+    test("should use resolver-provided url for relative module paths", async () => {
+      const resolver: ModuleResolver = {
+        resolve(specifier) {
+          if (specifier !== "dep.js") {
+            return null;
+          }
+          return {
+            type: "source",
+            code: "export const url = import.meta.url;",
+            path: "dep.js",
+          };
+        },
+        getImportMeta({ path }) {
+          return {
+            url: `https://cdn.example.com/modules/${path}`,
+          };
+        },
+      };
+
+      const interpreter = new Interpreter({
+        modules: { enabled: true, resolver },
+      });
+
+      const exports = await interpreter.evaluateModuleAsync(
+        `import { url } from "dep.js";
+        export { url };`,
+        { path: "/app/main.js" },
+      );
+
+      expect(exports.url).toBe("https://cdn.example.com/modules/dep.js");
+    });
+
+    test("should ignore resolver-provided url for absolute module paths", async () => {
+      const resolver: ModuleResolver = {
+        resolve(specifier) {
+          if (specifier !== "dep.js") {
+            return null;
+          }
+          return {
+            type: "source",
+            code: "export const url = import.meta.url;",
+            path: "/canonical/dep.js",
+          };
+        },
+        getImportMeta({ path }) {
+          return {
+            url: `https://cdn.example.com${path}`,
+          };
+        },
+      };
+
+      const interpreter = new Interpreter({
+        modules: { enabled: true, resolver },
+      });
+
+      const exports = await interpreter.evaluateModuleAsync(
+        `import { url } from "dep.js";
+        export { url };`,
+        { path: "/app/main.js" },
+      );
+
+      expect(exports.url).toBe("file:///canonical/dep.js");
+    });
+
+    test("should fall back to file:// url when resolver-provided url is invalid for relative paths", async () => {
+      const resolver: ModuleResolver = {
+        resolve(specifier) {
+          if (specifier !== "dep.js") {
+            return null;
+          }
+          return {
+            type: "source",
+            code: "export const url = import.meta.url;",
+            path: "dep.js",
+          };
+        },
+        getImportMeta() {
+          return { url: "not a valid url !!!" };
+        },
+      };
+
+      const interpreter = new Interpreter({
+        modules: { enabled: true, resolver },
+      });
+
+      const exports = await interpreter.evaluateModuleAsync(
+        `import { url } from "dep.js";
+        export { url };`,
+        { path: "/app/main.js" },
+      );
+
+      expect(exports.url).toBe("file:///dep.js");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #188.

- `createImportMetaUrl()` previously turned a relative resolver path like `dep.js` into `file:///dep.js` — a valid URL string but a misleading root-relative location that most embedders do not expect
- Embedders had no way to correct this: the `url` key returned by `getImportMeta` was silently skipped
- This PR allows `getImportMeta` to supply a canonical `url` for relative module paths. When the resolved `path` has no URL scheme and does not start with `/`, and the resolver's `getImportMeta` returns a valid absolute URL in the `url` field, that URL is used as `import.meta.url`
- Absolute paths (`/app/main.js` → `file:///app/main.js`) and paths that already carry a URL scheme are unaffected by this change

## Changes

- `src/interpreter.ts` — `createImportMetaUrl` accepts an optional `resolverUrl` parameter; for relative paths, attempts to parse it as an absolute URL before falling back to the existing `file:///` logic. `createModuleImportMeta` passes `importMetaExtensions?.url` through
- `test/modules.test.ts` — three new tests covering: resolver URL used for relative path, resolver URL ignored for absolute path, invalid resolver URL falls back to `file://`
- `.changeset/import-meta-url-relative-paths.md` — patch changeset

## Test plan

- [x] New regression tests added for all three cases (resolver URL for relative path, ignored for absolute path, fallback on invalid URL)
- [x] Existing `import.meta` test suite passes unchanged
- [x] Full test suite: 3662 pass, 0 fail
- [x] `bun typecheck`, `bun fmt`, `bun lint:fix` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)