### PR TITLE
fix(modules): throw on ambiguous export * conflicts

### DIFF
--- a/.changeset/ambiguous-export-star-conflicts.md
+++ b/.changeset/ambiguous-export-star-conflicts.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Throw on ambiguous `export *` conflicts instead of silently using first-wins semantics. When two `export * from` statements in the same module each provide the same binding name from different ultimate sources, an `InterpreterError` is now thrown to match standard ESM behaviour. Diamond-shaped re-export graphs (where the same binding is reachable via multiple paths but originates from a single module) continue to work without error, as they are not ambiguous per the ESM specification.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -20,6 +20,7 @@ import type {
   ModuleOptions,
   ModuleMetadata,
   ModuleRecord,
+  StarExportOrigin,
 } from "./modules";
 import type { NativeUnwrapAllowlistEntry } from "./readonly-proxy";
 
@@ -4067,6 +4068,11 @@ export class Interpreter {
       const exports: Record<string, any> = targetExports ?? {};
       const moduleEnv = new Environment(this.environment);
 
+      // Pre-compute direct export names so star re-exports can detect conflicts correctly.
+      // A name with a direct export always wins and never causes ambiguity.
+      const directExportNames = this.collectStaticExportNames(ast);
+      const starExportOrigins = new Map<string, StarExportOrigin>();
+
       for (const statement of ast.body) {
         if (statement.type === "ImportDeclaration") {
           await this.evaluateImportDeclaration(statement, moduleEnv, path);
@@ -4075,7 +4081,14 @@ export class Interpreter {
         } else if (statement.type === "ExportDefaultDeclaration") {
           await this.evaluateExportDefaultDeclaration(statement, moduleEnv, exports);
         } else if (statement.type === "ExportAllDeclaration") {
-          await this.evaluateExportAllDeclaration(statement, moduleEnv, exports, path);
+          await this.evaluateExportAllDeclaration(
+            statement,
+            moduleEnv,
+            exports,
+            path,
+            directExportNames,
+            starExportOrigins,
+          );
         } else {
           const prevEnv = this.environment;
           this.environment = moduleEnv;
@@ -4087,6 +4100,7 @@ export class Interpreter {
         }
       }
 
+      this.moduleSystem.setModuleStarExportOrigins(path, starExportOrigins);
       return ReadOnlyProxy.wrap(exports, "module.exports", this.securityOptions);
     } finally {
       this.moduleImportMetaStack.pop();
@@ -4533,6 +4547,8 @@ export class Interpreter {
     moduleEnv: Environment,
     exports: Record<string, any>,
     currentPath: string,
+    directExportNames: Set<string>,
+    starExportOrigins: Map<string, StarExportOrigin>,
   ): Promise<void> {
     const specifier = (node.source as ESTree.Literal).value as string;
     const sourceExports = await this.resolveModuleExports(specifier, currentPath);
@@ -4547,16 +4563,43 @@ export class Interpreter {
         moduleEnv.declare(node.exported.name, namespace, "const");
       }
     } else {
-      // Handle "export * from 'module'" - re-export all named exports
-      // Note: For diamond dependencies, the same export may come from multiple paths
-      // We only add to exports (not moduleEnv) to avoid duplicate declaration errors
+      // Handle "export * from 'module'" - re-export all named exports.
+      // Per ESM spec, star re-exports that conflict (same name, different ultimate binding)
+      // are ambiguous and must throw. Diamond dependencies (same name, same ultimate
+      // binding reachable via multiple paths) are allowed.
+      const sourceRecord = await this.moduleSystem!.resolveModule(specifier, currentPath);
+      const sourcePath = sourceRecord?.path ?? specifier;
+      const sourceStarOrigins = this.moduleSystem!.getModuleStarExportOrigins(sourcePath);
+
       for (const key of Object.keys(sourceExports)) {
-        // Skip 'default' export per ES module spec
-        if (key !== "default") {
-          // Only add if not already exported (first one wins per ES spec)
-          if (!(key in exports)) {
-            this.defineLiveExport(exports, key, () => sourceExportsTarget[key]);
+        if (key === "default") continue;
+
+        // Direct exports always win; never count as a star-export conflict.
+        if (directExportNames.has(key)) continue;
+
+        // Determine the ultimate binding origin for this name.
+        // If the source module re-exported it via export *, use that origin.
+        // Otherwise the source module defines it directly, so it is its own origin.
+        const origin: StarExportOrigin = sourceStarOrigins?.get(key) ?? {
+          path: sourcePath,
+          name: key,
+        };
+
+        if (!(key in exports)) {
+          this.defineLiveExport(exports, key, () => sourceExportsTarget[key]);
+          starExportOrigins.set(key, origin);
+        } else {
+          const existingOrigin = starExportOrigins.get(key);
+          if (
+            existingOrigin &&
+            (existingOrigin.path !== origin.path || existingOrigin.name !== origin.name)
+          ) {
+            throw new InterpreterError(
+              `The requested module provides an ambiguous export '${key}'`,
+            );
           }
+          // Either same ultimate binding (diamond dep) or a direct export already owns
+          // this name — either way, skip silently.
         }
       }
     }

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -4131,22 +4131,27 @@ export class Interpreter {
         if (statement.specifiers) {
           for (const specifier of statement.specifiers) {
             if (
-              (specifier.type === "ExportSpecifier" ||
-                specifier.type === "ExportDefaultSpecifier") &&
-              specifier.exported.type === "Identifier"
+              specifier.type === "ExportSpecifier" ||
+              specifier.type === "ExportDefaultSpecifier"
             ) {
-              exportNames.add(specifier.exported.name);
+              // ESTree types the exported name as Identifier, but parsers that
+              // implement ES2022 string export names may emit a Literal node.
+              // Cast defensively so both forms are captured.
+              const exportedNode = specifier.exported as ESTree.Identifier | ESTree.Literal;
+              const exportedName =
+                exportedNode.type === "Identifier" ? exportedNode.name : String(exportedNode.value);
+              exportNames.add(exportedName);
             }
           }
         }
       } else if (statement.type === "ExportDefaultDeclaration") {
         exportNames.add("default");
-      } else if (
-        statement.type === "ExportAllDeclaration" &&
-        statement.exported &&
-        statement.exported.type === "Identifier"
-      ) {
-        exportNames.add(statement.exported.name);
+      } else if (statement.type === "ExportAllDeclaration" && statement.exported) {
+        // Same defensive cast as above.
+        const exportedNode = statement.exported as ESTree.Identifier | ESTree.Literal;
+        const exportedName =
+          exportedNode.type === "Identifier" ? exportedNode.name : String(exportedNode.value);
+        exportNames.add(exportedName);
       }
     }
 
@@ -4268,10 +4273,10 @@ export class Interpreter {
   /**
    * Resolve a module specifier and return its exports, evaluating if needed.
    */
-  private async resolveModuleExports(
+  private async resolveModuleRecordWithExports(
     specifier: string,
     importerPath: string | null,
-  ): Promise<Record<string, any>> {
+  ): Promise<{ record: ModuleRecord; exports: Record<string, any> }> {
     if (!this.moduleSystem) {
       throw new InterpreterError("Module system is not enabled");
     }
@@ -4282,7 +4287,7 @@ export class Interpreter {
     }
 
     if (moduleRecord.status === "initialized") {
-      return moduleRecord.exports;
+      return { record: moduleRecord, exports: moduleRecord.exports };
     }
 
     if (moduleRecord.status === "failed") {
@@ -4292,7 +4297,7 @@ export class Interpreter {
     // Circular import: this module is already being evaluated in the active chain.
     // Reuse in-progress exports to avoid recursive re-entry and depth-limit failures.
     if (this.moduleSystem.getImporterChain().includes(moduleRecord.path)) {
-      return moduleRecord.exports;
+      return { record: moduleRecord, exports: moduleRecord.exports };
     }
 
     try {
@@ -4316,12 +4321,19 @@ export class Interpreter {
         moduleRecord.exports,
       );
       this.moduleSystem.setModuleExports(moduleRecord.path, exports);
-      return exports;
+      return { record: moduleRecord, exports };
     } catch (error) {
       const moduleError = error instanceof Error ? error : new Error(String(error));
       this.moduleSystem.setModuleFailed(moduleRecord.path, moduleError);
       throw error;
     }
+  }
+
+  private async resolveModuleExports(
+    specifier: string,
+    importerPath: string | null,
+  ): Promise<Record<string, any>> {
+    return (await this.resolveModuleRecordWithExports(specifier, importerPath)).exports;
   }
 
   private async evaluateImportDeclaration(
@@ -4551,7 +4563,8 @@ export class Interpreter {
     starExportOrigins: Map<string, StarExportOrigin>,
   ): Promise<void> {
     const specifier = (node.source as ESTree.Literal).value as string;
-    const sourceExports = await this.resolveModuleExports(specifier, currentPath);
+    const { record: sourceRecord, exports: sourceExports } =
+      await this.resolveModuleRecordWithExports(specifier, currentPath);
     const sourceExportsTarget = this.getModuleExportsTarget(sourceExports);
 
     // Handle "export * as namespace from 'module'"
@@ -4567,8 +4580,7 @@ export class Interpreter {
       // Per ESM spec, star re-exports that conflict (same name, different ultimate binding)
       // are ambiguous and must throw. Diamond dependencies (same name, same ultimate
       // binding reachable via multiple paths) are allowed.
-      const sourceRecord = await this.moduleSystem!.resolveModule(specifier, currentPath);
-      const sourcePath = sourceRecord?.path ?? specifier;
+      const sourcePath = sourceRecord.path;
       const sourceStarOrigins = this.moduleSystem!.getModuleStarExportOrigins(sourcePath);
 
       for (const key of Object.keys(sourceExports)) {

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -343,6 +343,11 @@ export interface ModuleMetadata {
   error?: Error;
 }
 
+export interface StarExportOrigin {
+  path: string;
+  name: string;
+}
+
 export interface ModuleRecord {
   importer: string | null;
   path: string;
@@ -354,6 +359,7 @@ export interface ModuleRecord {
   source?: string;
   ast?: ESTree.Program;
   loadedAt: number;
+  starExportOrigins?: Map<string, StarExportOrigin>;
 }
 
 /**
@@ -704,6 +710,23 @@ export class ModuleSystem {
       record.status = "initialized";
       this.options.resolver.onLoad?.(record.specifier, path, record.exports);
     }
+  }
+
+  /**
+   * Store the star export binding origins for a module after evaluation.
+   */
+  setModuleStarExportOrigins(path: string, origins: Map<string, StarExportOrigin>): void {
+    const record = this.cacheByPath.get(path);
+    if (record) {
+      record.starExportOrigins = origins;
+    }
+  }
+
+  /**
+   * Get the star export binding origins for a module.
+   */
+  getModuleStarExportOrigins(path: string): Map<string, StarExportOrigin> | undefined {
+    return this.cacheByPath.get(path)?.starExportOrigins;
   }
 
   /**

--- a/test/modules.test.ts
+++ b/test/modules.test.ts
@@ -3009,7 +3009,7 @@ describe("Module System", () => {
   // ============================================================================
 
   describe("Export * Conflict Handling", () => {
-    test("should use first export when same name comes from multiple sources", async () => {
+    test("should throw on ambiguous export when same name comes from multiple star sources", async () => {
       const files = new Map([
         ["first.js", "export const shared = 'first';"],
         ["second.js", "export const shared = 'second';"],
@@ -3028,15 +3028,40 @@ describe("Module System", () => {
         modules: { enabled: true, resolver },
       });
 
-      const result = await interpreter.evaluateModuleAsync(
-        `import { shared } from "barrel.js"; export const value = shared;`,
-        { path: "main.js" },
-      );
-      // First export * wins
-      expect(result.value).toBe("first");
+      await expect(
+        interpreter.evaluateModuleAsync(
+          `import { shared } from "barrel.js"; export const value = shared;`,
+          { path: "main.js" },
+        ),
+      ).rejects.toThrow("ambiguous export 'shared'");
     });
 
-    test("should allow local export to override re-exported name", async () => {
+    test("should throw on ambiguous export from chained star re-exports", async () => {
+      const files = new Map([
+        ["a.js", "export const foo = 'a';"],
+        ["b.js", "export const foo = 'b';"],
+        ["mid.js", "export * from 'a.js'; export * from 'b.js';"],
+        ["top.js", "export * from 'mid.js';"],
+      ]);
+
+      const resolver: ModuleResolver = {
+        resolve(specifier) {
+          const code = files.get(specifier);
+          if (!code) return null;
+          return { type: "source", code, path: specifier };
+        },
+      };
+
+      const interpreter = new Interpreter({
+        modules: { enabled: true, resolver },
+      });
+
+      await expect(
+        interpreter.evaluateModuleAsync(`import { foo } from "top.js";`, { path: "main.js" }),
+      ).rejects.toThrow("ambiguous export 'foo'");
+    });
+
+    test("should allow local export to override re-exported name without conflict", async () => {
       const files = new Map([
         ["source.js", "export const value = 'from-source';"],
         ["barrel.js", "export * from 'source.js'; export const value = 'local';"],
@@ -3058,8 +3083,86 @@ describe("Module System", () => {
         `import { value } from "barrel.js"; export const v = value;`,
         { path: "main.js" },
       );
-      // Local export should override re-exported
       expect(result.v).toBe("local");
+    });
+
+    test("should allow local export defined before star re-export to win without conflict", async () => {
+      const files = new Map([
+        ["source.js", "export const value = 'from-source';"],
+        ["barrel.js", "export const value = 'local'; export * from 'source.js';"],
+      ]);
+
+      const resolver: ModuleResolver = {
+        resolve(specifier) {
+          const code = files.get(specifier);
+          if (!code) return null;
+          return { type: "source", code, path: specifier };
+        },
+      };
+
+      const interpreter = new Interpreter({
+        modules: { enabled: true, resolver },
+      });
+
+      const result = await interpreter.evaluateModuleAsync(
+        `import { value } from "barrel.js"; export const v = value;`,
+        { path: "main.js" },
+      );
+      expect(result.v).toBe("local");
+    });
+
+    test("should not throw for diamond dependency pattern (same binding via multiple paths)", async () => {
+      const files = new Map([
+        ["base.js", "export const BASE = 'base';"],
+        ["left.js", "export * from 'base.js'; export const LEFT = 'left';"],
+        ["right.js", "export * from 'base.js'; export const RIGHT = 'right';"],
+        ["top.js", "export * from 'left.js'; export * from 'right.js';"],
+      ]);
+
+      const resolver: ModuleResolver = {
+        resolve(specifier) {
+          const code = files.get(specifier);
+          if (!code) return null;
+          return { type: "source", code, path: specifier };
+        },
+      };
+
+      const interpreter = new Interpreter({
+        modules: { enabled: true, resolver },
+      });
+
+      const result = await interpreter.evaluateModuleAsync(
+        `import { BASE, LEFT, RIGHT } from "top.js"; export const all = BASE + LEFT + RIGHT;`,
+        { path: "main.js" },
+      );
+      expect(result.all).toBe("baseleftright");
+    });
+
+    test("should not throw for name shared across two star exports when both originate from the same source", async () => {
+      const files = new Map([
+        ["origin.js", "export const x = 42;"],
+        ["re1.js", "export * from 'origin.js';"],
+        ["re2.js", "export * from 'origin.js';"],
+        ["barrel.js", "export * from 're1.js'; export * from 're2.js';"],
+      ]);
+
+      const resolver: ModuleResolver = {
+        resolve(specifier) {
+          const code = files.get(specifier);
+          if (!code) return null;
+          return { type: "source", code, path: specifier };
+        },
+      };
+
+      const interpreter = new Interpreter({
+        modules: { enabled: true, resolver },
+      });
+
+      const result = await interpreter.evaluateModuleAsync(
+        `import { x } from "barrel.js"; export const val = x;`,
+        { path: "main.js" },
+      );
+      expect(result.val).toBe(42);
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #189.

Previously, when two `export * from` statements in the same module each provided the same binding name, the interpreter silently used first-wins semantics. The ESM spec instead treats such cases as *ambiguous* and requires an error to be thrown.

- **True conflicts** (same name from two different ultimate sources): now throws `InterpreterError: The requested module provides an ambiguous export '<name>'`
- **Diamond dependencies** (same name reachable via multiple intermediate modules but tracing back to one origin): still allowed, matching the ESM spec
- **Local/direct exports**: continue to shadow star re-exports without any conflict

## Implementation

Each `export *` declaration now tracks the *ultimate binding origin* `{ path, name }` for every name it contributes. The origin is propagated transitively through re-export chains so that diamond-shaped graphs can be correctly identified. The origins are stored per-module in `ModuleRecord.starExportOrigins` and queried when a subsequent star export provides a name that is already present:

- Same origin → diamond dep → skip silently
- Different origin → ambiguous → throw
- Name has a direct local export → direct export wins → skip silently

## Test plan

- [x] Existing diamond dependency test still passes (`baseleftright`)
- [x] New: two `export *` with conflicting names throws on import
- [x] New: ambiguity propagated through chained star re-exports
- [x] New: local export before `export *` wins without conflict
- [x] New: local export after `export *` wins without conflict
- [x] New: deeper diamond (same binding via 3 levels of re-export) resolves cleanly
- [x] Full test suite: 3666 tests, 0 failures
- [x] TypeScript typecheck passes
- [x] Linter passes (warnings are pre-existing)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)