### PR TITLE
[codex] fix mutable Object.create sandbox results

### DIFF
--- a/.changeset/green-timers-sneeze.md
+++ b/.changeset/green-timers-sneeze.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Fix `Object.create()` so sandbox-created prototype objects produce mutable sandbox-owned results instead of read-only host proxies.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -6141,20 +6141,23 @@ export class Interpreter {
         }
       }
 
+      const materialized = Object.create(null) as Record<string | symbol, any>;
+      seen.set(value, materialized);
+
       const materializedPrototype = this.resolveMaterializedHostPrototype(
         Object.getPrototypeOf(value),
         name,
         seen,
       );
       if (materializedPrototype === undefined) {
+        seen.delete(value);
         return this.wrapHostFallbackValue(value, name, seen);
       }
 
-      const materialized = Object.create(materializedPrototype) as Record<string | symbol, any>;
-      seen.set(value, materialized);
       if (materializedPrototype === null) {
         this.markSandboxContainer(materialized);
       } else {
+        Object.setPrototypeOf(materialized, materializedPrototype);
         this.markSandboxPrototypeLinkedContainer(materialized);
       }
 

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -2643,6 +2643,7 @@ export class Interpreter {
   private currentSuperBinding: SuperBinding | null = null;
   private instanceClassMap: WeakMap<object, ClassValue> = new WeakMap();
   private sandboxOwnedContainers: WeakSet<object> = new WeakSet();
+  private sandboxPrototypeLinkedContainers: WeakSet<object> = new WeakSet();
   private arrayMethodCache: WeakMap<any[], Map<string, HostFunctionValue>> = new WeakMap();
   private generatorMethodCache: WeakMap<GeneratorValue, Map<string, HostFunctionValue>> =
     new WeakMap();
@@ -5898,6 +5899,9 @@ export class Interpreter {
     if (Object.getPrototypeOf(object) === null) {
       return;
     }
+    if (this.sandboxPrototypeLinkedContainers.has(object)) {
+      return;
+    }
     // Allow Symbol.iterator for iteration protocol support
     if (property === Symbol.iterator) {
       return;
@@ -5943,6 +5947,9 @@ export class Interpreter {
       return;
     }
     if (Object.getPrototypeOf(object) === null) {
+      return;
+    }
+    if (this.sandboxPrototypeLinkedContainers.has(object)) {
       return;
     }
     if (object instanceof RegExp) {
@@ -6002,6 +6009,12 @@ export class Interpreter {
     return value;
   }
 
+  private markSandboxPrototypeLinkedContainer<T extends object>(value: T): T {
+    this.sandboxOwnedContainers.add(value);
+    this.sandboxPrototypeLinkedContainers.add(value);
+    return value;
+  }
+
   private defineMaterializedDataProperty(
     target: object,
     key: PropertyKey,
@@ -6025,6 +6038,33 @@ export class Interpreter {
     const wrapped = ReadOnlyProxy.wrap(value, name, this.securityOptions);
     seen.set(value, wrapped);
     return wrapped;
+  }
+
+  private resolveMaterializedHostPrototype(
+    prototype: any,
+    name: string,
+    seen: WeakMap<object, any>,
+  ): object | null | undefined {
+    if (prototype === null || prototype === Object.prototype) {
+      return null;
+    }
+
+    if (typeof prototype !== "object") {
+      return undefined;
+    }
+
+    const materializedPrototype = this.wrapHostReturnValue(prototype, `${name}.__proto__`, seen);
+    if (
+      materializedPrototype === null ||
+      typeof materializedPrototype !== "object" ||
+      Array.isArray(materializedPrototype) ||
+      this.isReadOnlyProxyObject(materializedPrototype) ||
+      this.instanceClassMap.has(materializedPrototype)
+    ) {
+      return undefined;
+    }
+
+    return materializedPrototype;
   }
 
   private wrapHostReturnValue(
@@ -6089,28 +6129,37 @@ export class Interpreter {
       return materialized;
     }
 
-    if (this.isPlainObjectLike(value)) {
+    if (typeof value === "object" && value !== null) {
       const descriptors = Object.getOwnPropertyDescriptors(value);
       for (const key of Reflect.ownKeys(descriptors)) {
         if (isDangerousProperty(key)) {
           return this.wrapHostFallbackValue(value, name, seen);
         }
-        const descriptor = descriptors[key as keyof typeof descriptors] as
-          | PropertyDescriptor
-          | undefined;
+        const descriptor = Object.getOwnPropertyDescriptor(value, key);
         if (descriptor && ("get" in descriptor || "set" in descriptor)) {
           return this.wrapHostFallbackValue(value, name, seen);
         }
       }
 
-      const materialized = Object.create(null) as Record<string | symbol, any>;
+      const materializedPrototype = this.resolveMaterializedHostPrototype(
+        Object.getPrototypeOf(value),
+        name,
+        seen,
+      );
+      if (materializedPrototype === undefined) {
+        return this.wrapHostFallbackValue(value, name, seen);
+      }
+
+      const materialized = Object.create(materializedPrototype) as Record<string | symbol, any>;
       seen.set(value, materialized);
-      this.markSandboxContainer(materialized);
+      if (materializedPrototype === null) {
+        this.markSandboxContainer(materialized);
+      } else {
+        this.markSandboxPrototypeLinkedContainer(materialized);
+      }
 
       for (const key of Reflect.ownKeys(descriptors)) {
-        const descriptor = descriptors[key as keyof typeof descriptors] as
-          | PropertyDescriptor
-          | undefined;
+        const descriptor = Object.getOwnPropertyDescriptor(value, key);
         if (!descriptor || !("value" in descriptor)) {
           continue;
         }

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -868,6 +868,26 @@ describe("Objects", () => {
           `);
           expect(result).toEqual([1, undefined, true, false, true]);
         });
+
+        it("should preserve multi-level sandbox prototype chains", () => {
+          const result = interpreter.evaluate(`
+            const grandproto = { root: 1 };
+            const proto = Object.create(grandproto);
+            proto.middle = 2;
+
+            const obj = Object.create(proto);
+            obj.leaf = 3;
+
+            [
+              obj.root,
+              obj.middle,
+              obj.leaf,
+              Object.getPrototypeOf(obj) === proto,
+              Object.getPrototypeOf(proto) === grandproto,
+            ];
+          `);
+          expect(result).toEqual([1, 2, 3, true, true]);
+        });
       });
 
       describe("Object.keys", () => {

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -833,6 +833,41 @@ describe("Objects", () => {
           `);
           expect(result).toBe(1);
         });
+
+        it("should return a mutable sandbox object with its sandbox prototype preserved", () => {
+          const result = interpreter.evaluate(`
+            const proto = { inherited: 1 };
+            const obj = Object.create(proto);
+            obj.own = 2;
+            const deleted = delete obj.own;
+            [
+              obj.inherited,
+              obj.own,
+              deleted,
+              "own" in obj,
+              Object.getPrototypeOf(obj) === proto,
+            ];
+          `);
+          expect(result).toEqual([1, undefined, true, false, true]);
+        });
+
+        it("should preserve mutable Object.create results in async evaluation", async () => {
+          const asyncInterpreter = new Interpreter(ES2024);
+          const result = await asyncInterpreter.evaluateAsync(`
+            const proto = { inherited: 1 };
+            const obj = Object.create(proto);
+            obj.own = 2;
+            const deleted = delete obj.own;
+            [
+              obj.inherited,
+              obj.own,
+              deleted,
+              "own" in obj,
+              Object.getPrototypeOf(obj) === proto,
+            ];
+          `);
+          expect(result).toEqual([1, undefined, true, false, true]);
+        });
       });
 
       describe("Object.keys", () => {

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -882,6 +882,47 @@ describe("Security", () => {
         expect(Object.getPrototypeOf(hostObject)).toBe(Object.prototype);
       });
 
+      it("should fall back to read-only proxies for host objects with accessor-backed prototypes", () => {
+        const hostProto: Record<string, unknown> = {};
+        Object.defineProperty(hostProto, "computed", {
+          get: () => 2,
+          enumerable: true,
+          configurable: true,
+        });
+        const hostObject = Object.create(hostProto) as Record<string, unknown>;
+        hostObject.safe = 1;
+
+        const interpreter = new Interpreter({
+          globals: {
+            getAccessorPrototypeObject: () => hostObject,
+          },
+        });
+
+        const result = interpreter.evaluate(`
+          const obj = getAccessorPrototypeObject();
+          [obj.safe, obj.computed, obj];
+        `);
+
+        expect(result[0]).toBe(1);
+        expect(result[1]).toBe(2);
+        expect(Object.getPrototypeOf(result[2])).toBeNull();
+
+        const mutationInterpreter = new Interpreter({
+          globals: {
+            getAccessorPrototypeObject: () => hostObject,
+          },
+        });
+        expect(() => {
+          mutationInterpreter.evaluate(`
+            const proxied = getAccessorPrototypeObject();
+            proxied.safe = 2;
+          `);
+        }).toThrow(
+          "Cannot modify property 'safe' on global 'getAccessorPrototypeObject' (read-only)",
+        );
+        expect(hostObject.safe).toBe(1);
+      });
+
       it("should preserve circular references when materializing host objects", () => {
         const circular: any = { count: 1 };
         circular.self = circular;

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -944,6 +944,30 @@ describe("Security", () => {
         expect(result).toEqual([true, 2]);
         expect(circular.count).toBe(1);
       });
+
+      it("should preserve identity for prototype-mediated back-references", () => {
+        const proto: Record<string, unknown> = {};
+        const child = Object.create(proto) as Record<string, unknown>;
+        proto.backRef = child;
+        child.parent = proto;
+        child.value = 1;
+
+        const interpreter = new Interpreter({
+          globals: {
+            getPrototypeCycleObject: () => child,
+          },
+        });
+
+        const result = interpreter.evaluate(`
+          const obj = getPrototypeCycleObject();
+          [
+            obj === obj.parent.backRef,
+            obj.parent.backRef.value,
+          ];
+        `);
+
+        expect(result).toEqual([true, 1]);
+      });
     });
 
     describe("edge cases", () => {


### PR DESCRIPTION
Closes #201.

## What changed
- materialize host-returned plain objects as mutable sandbox-owned objects when their prototype can be reduced to a safe sandbox-owned prototype chain
- preserve the sandbox prototype for `Object.create(proto)` results instead of falling back to a read-only proxy
- continue falling back to read-only proxy wrapping for unsafe prototype shapes
- add sync and async regression coverage for mutation, deletion, inherited reads, and prototype preservation
- add a patch changeset for the fix

## Why this changed
`Object.create(proto)` was calling the host built-in and receiving a host object whose prototype pointed at a sandbox object. The interpreter only materialized plain host objects with `Object.prototype` or `null` prototypes, so these results fell through to `ReadOnlyProxy`. That made the returned object behave like a protected host global rather than a normal sandbox-owned container.

## User impact
Sandbox code can now use `Object.create(proto)` for normal prototype-based object construction. Returned objects remain mutable, retain the intended sandbox prototype, and do not expose raw host objects.

## Validation
- `bun fmt`
- `bun run lint:fix` (warnings only, no errors)
- `bun run typecheck`
- `bun test`
- `bun test test/objects.test.ts -t "Object.create"`
- `bun test test/objects.test.ts`
- `bun test test/security.test.ts -t "materialize plain host objects|preserve circular references when materializing host objects|Object.getPrototypeOf"`