### PR TITLE
[codex] fix for-in inherited key enumeration

### DIFF
--- a/.changeset/tender-keys-walk.md
+++ b/.changeset/tender-keys-walk.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Fix `for...in` enumeration so inherited enumerable properties are included while shadowed keys are not duplicated.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -418,6 +418,14 @@ function extractForInVariable(left: ESTree.ForInStatement["left"]): {
   throw new InterpreterError("Unsupported for...in left-hand side");
 }
 
+function enumerateForInKeys(obj: object): string[] {
+  const keys: string[] = [];
+  for (const key in obj) {
+    keys.push(key);
+  }
+  return keys;
+}
+
 /**
  * Represents a synchronous generator instance created by calling a generator function.
  * Implements the iterator protocol with next(), return(), and throw().
@@ -867,8 +875,7 @@ class GeneratorValue extends BaseGeneratorValue {
 
       const { variableName, isDeclaration, variableKind } = extractForInVariable(node.left);
 
-      // Iterate over object keys
-      const keys = Object.keys(obj);
+      const keys = enumerateForInKeys(obj);
 
       for (const key of keys) {
         if (isDeclaration) {
@@ -1542,8 +1549,7 @@ class AsyncGeneratorValue extends BaseGeneratorValue {
 
       const { variableName, isDeclaration, variableKind } = extractForInVariable(node.left);
 
-      // Iterate over object keys
-      const keys = Object.keys(obj);
+      const keys = enumerateForInKeys(obj);
 
       for (const key of keys) {
         if (isDeclaration) {
@@ -8013,9 +8019,7 @@ export class Interpreter {
       let result: any = undefined;
       let iterations = 0;
 
-      // Iterate over object keys (own enumerable properties)
-      // Use Object.keys to get own enumerable property names
-      const keys = Object.keys(obj);
+      const keys = enumerateForInKeys(obj);
 
       for (const key of keys) {
         // Check execution limits at the start of each loop iteration
@@ -11435,8 +11439,7 @@ export class Interpreter {
       let result: any = undefined;
       let iterations = 0;
 
-      // Iterate over object keys (own enumerable properties)
-      const keys = Object.keys(obj);
+      const keys = enumerateForInKeys(obj);
 
       for (const key of keys) {
         // Check execution limits at the start of each loop iteration

--- a/test/control-flow.test.ts
+++ b/test/control-flow.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, test, expect, beforeEach } from "bun:test";
 
 import { Interpreter, InterpreterError } from "../src/interpreter";
+import { ES2022 } from "../src/presets";
 import { createSandbox } from "../src/sandbox";
 
 describe("Control Flow", () => {
@@ -3050,6 +3051,55 @@ describe("Control Flow", () => {
               keys.push(key);
             }
             keys
+          `);
+          expect(result).toEqual(["own", "shadowed", "inherited"]);
+        });
+      });
+
+      describe("for...in in generators", () => {
+        it("should iterate inherited enumerable keys from generator functions", () => {
+          const interpreter = new Interpreter(ES2022);
+          const result = interpreter.evaluate(`
+            let proto = { inherited: 1, shadowed: "proto" };
+            let obj = Object.create(proto);
+            obj.own = 2;
+            obj.shadowed = "own";
+            function* keysOf(value) {
+              for (let key in value) {
+                yield key;
+              }
+            }
+            let keys = [];
+            let iterator = keysOf(obj);
+            keys.push(iterator.next().value);
+            keys.push(iterator.next().value);
+            keys.push(iterator.next().value);
+            keys
+          `);
+          expect(result).toEqual(["own", "shadowed", "inherited"]);
+        });
+
+        it("should iterate inherited enumerable keys from async generator functions", async () => {
+          const interpreter = new Interpreter(ES2022);
+          const result = await interpreter.evaluateAsync(`
+            async function run() {
+              let proto = { inherited: 1, shadowed: "proto" };
+              let obj = Object.create(proto);
+              obj.own = 2;
+              obj.shadowed = "own";
+              async function* keysOf(value) {
+                for (let key in value) {
+                  yield key;
+                }
+              }
+              const iterator = keysOf(obj);
+              const results = [];
+              results.push((await iterator.next()).value);
+              results.push((await iterator.next()).value);
+              results.push((await iterator.next()).value);
+              return results;
+            }
+            run()
           `);
           expect(result).toEqual(["own", "shadowed", "inherited"]);
         });

--- a/test/control-flow.test.ts
+++ b/test/control-flow.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, test, expect, beforeEach } from "bun:test";
 
 import { Interpreter, InterpreterError } from "../src/interpreter";
+import { createSandbox } from "../src/sandbox";
 
 describe("Control Flow", () => {
   describe("ES5", () => {
@@ -2671,6 +2672,22 @@ describe("Control Flow", () => {
           `);
           expect(result).toBe("y"); // Last key assigned
         });
+
+        it("should iterate inherited enumerable keys without duplicating shadowed keys", () => {
+          const sandbox = createSandbox({ env: "es2022" });
+          const result = sandbox.runSync(`
+            let proto = { inherited: 1, shadowed: "proto" };
+            let obj = Object.create(proto);
+            obj.own = 2;
+            obj.shadowed = "own";
+            let keys = [];
+            for (let key in obj) {
+              keys.push(key);
+            }
+            keys
+          `);
+          expect(result).toEqual(["own", "shadowed", "inherited"]);
+        });
       });
 
       describe("for...in with arrays", () => {
@@ -3019,6 +3036,22 @@ describe("Control Flow", () => {
             sum
           `);
           expect(result).toBe(30); // (5*2) + (10*2)
+        });
+
+        it("should iterate inherited enumerable keys in evaluateAsync", async () => {
+          const sandbox = createSandbox({ env: "es2022" });
+          const result = await sandbox.run(`
+            let proto = { inherited: 1, shadowed: "proto" };
+            let obj = Object.create(proto);
+            obj.own = 2;
+            obj.shadowed = "own";
+            let keys = [];
+            for (let key in obj) {
+              keys.push(key);
+            }
+            keys
+          `);
+          expect(result).toEqual(["own", "shadowed", "inherited"]);
         });
       });
 


### PR DESCRIPTION
## Summary

Fixes #202.

`for...in` now enumerates keys using native `for...in` semantics instead of `Object.keys()`. This makes the interpreter include inherited enumerable string properties while preserving native behavior for shadowed keys, so a shadowed property is yielded once from the object itself rather than duplicated from the prototype chain.

## Root Cause

All sync and async `for...in` execution paths were snapshotting iteration keys with `Object.keys(obj)`. `Object.keys()` only returns own enumerable properties, so objects created with enumerable prototype properties, including `Object.create(proto)`, silently skipped inherited keys.

## Changes

- Added a shared `enumerateForInKeys()` helper that captures native `for...in` key order and shadowing behavior.
- Reused that helper in generator sync, generator async, direct sync, and direct async `ForInStatement` execution paths.
- Added sync and async ES2022 sandbox regression coverage for own, inherited, and shadowed enumerable properties.
- Added a patch changeset.

## Validation

- `bun fmt`
- `bun lint:fix` (completed with existing warnings only)
- `bun test test/control-flow.test.ts`
- `bun test`
- `bun typecheck`