### PR TITLE
[codex] Fix object spread symbol keys

### DIFF
--- a/.changeset/silver-symbols-spread.md
+++ b/.changeset/silver-symbols-spread.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Fix object spread so enumerable symbol-keyed properties are copied in sync and async evaluation.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -12180,7 +12180,7 @@ export class Interpreter {
     }
 
     // Track memory: estimate 64 bytes base + 32 bytes per property
-    const propertyCount = Object.keys(obj).length;
+    const propertyCount = Reflect.ownKeys(obj).length;
     this.trackMemory(64 + propertyCount * 32);
 
     return this.markSandboxContainer(obj);

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -5748,6 +5748,20 @@ export class Interpreter {
     }
   }
 
+  private copyObjectSpreadProperties(target: Record<PropertyKey, any>, source: object): void {
+    for (const key of Reflect.ownKeys(source)) {
+      if (!Object.prototype.propertyIsEnumerable.call(source, key)) {
+        continue;
+      }
+
+      if (typeof key === "string") {
+        validatePropertyName(key); // Security: prevent prototype pollution
+      }
+
+      target[key] = (source as Record<PropertyKey, any>)[key];
+    }
+  }
+
   /**
    * Parse function parameters from AST nodes into the arrays/maps needed by FunctionValue.
    * Handles Identifier, RestElement, AssignmentPattern, ObjectPattern, and ArrayPattern.
@@ -10005,7 +10019,7 @@ export class Interpreter {
       throw new InterpreterError("ObjectLiterals is not enabled");
     }
 
-    const obj: Record<string, any> = {};
+    const obj: Record<PropertyKey, any> = {};
 
     for (const property of node.properties) {
       if (property.type === "SpreadElement") {
@@ -10017,11 +10031,7 @@ export class Interpreter {
         const spreadValue = this.evaluateNode((property as ESTree.SpreadElement).argument);
         this.validateObjectSpread(spreadValue);
 
-        // Merge properties from spread object
-        for (const [key, value] of Object.entries(spreadValue)) {
-          validatePropertyName(key); // Security: prevent prototype pollution
-          obj[key] = value;
-        }
+        this.copyObjectSpreadProperties(obj, spreadValue);
       } else if (property.type === "Property") {
         // Get the property key - evaluate expression for computed properties
         const computedKey = property.computed ? this.evaluateNode(property.key) : null;
@@ -10062,7 +10072,7 @@ export class Interpreter {
     }
 
     // Track memory: estimate 64 bytes base + 32 bytes per property
-    const propertyCount = Object.keys(obj).length;
+    const propertyCount = Reflect.ownKeys(obj).length;
     this.trackMemory(64 + propertyCount * 32);
 
     return this.markSandboxContainer(obj);
@@ -12119,7 +12129,7 @@ export class Interpreter {
       throw new InterpreterError("ObjectLiterals is not enabled");
     }
 
-    const obj: Record<string, any> = {};
+    const obj: Record<PropertyKey, any> = {};
 
     for (const property of node.properties) {
       if (property.type === "SpreadElement") {
@@ -12129,11 +12139,7 @@ export class Interpreter {
         );
         this.validateObjectSpread(spreadValue);
 
-        // Merge properties from spread object
-        for (const [key, value] of Object.entries(spreadValue)) {
-          validatePropertyName(key); // Security: prevent prototype pollution
-          obj[key] = value;
-        }
+        this.copyObjectSpreadProperties(obj, spreadValue);
       } else if (property.type === "Property") {
         // Evaluate expression for computed properties
         const computedKey = property.computed ? await this.evaluateNodeAsync(property.key) : null;

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -1764,6 +1764,30 @@ describe("Objects", () => {
         `);
         expect(result).toEqual({ a: 1, b: 3, c: 4 });
       });
+
+      it("should copy enumerable symbol keys with spread", () => {
+        const result = interpreter.evaluate(`
+          const sym = Symbol("metadata");
+          const hidden = Symbol("hidden");
+          const base = { [sym]: 123, a: 1 };
+          Object.defineProperty(base, hidden, { value: 456, enumerable: false });
+          const out = { ...base, b: 2 };
+          [out[sym], Object.getOwnPropertySymbols(out).length, out.a, out.b];
+        `);
+        expect(result).toEqual([123, 1, 1, 2]);
+      });
+
+      it("should copy enumerable symbol keys with spread in evaluateAsync", async () => {
+        const result = await interpreter.evaluateAsync(`
+          const sym = Symbol("metadata");
+          const hidden = Symbol("hidden");
+          const base = { [sym]: 123, a: 1 };
+          Object.defineProperty(base, hidden, { value: 456, enumerable: false });
+          const out = { ...base, b: 2 };
+          [out[sym], Object.getOwnPropertySymbols(out).length, out.a, out.b];
+        `);
+        expect(result).toEqual([123, 1, 1, 2]);
+      });
     });
 
     describe("Object rest", () => {

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -1788,6 +1788,19 @@ describe("Objects", () => {
         `);
         expect(result).toEqual([123, 1, 1, 2]);
       });
+
+      it("should count spread symbol keys against async memory limits", () => {
+        return expect(
+          interpreter.evaluateAsync(
+            `
+              const sym = Symbol("metadata");
+              const base = { [sym]: 123, a: 1 };
+              ({ ...base });
+            `,
+            { maxMemory: 240 },
+          ),
+        ).rejects.toThrow("Maximum memory limit exceeded");
+      });
     });
 
     describe("Object rest", () => {


### PR DESCRIPTION
## Summary

Fixes #203 by updating object-literal spread evaluation to copy enumerable own symbol keys as well as enumerable string keys.

## Root Cause

Object spread used `Object.entries(spreadValue)`, which only returns enumerable string-keyed properties. That meant enumerable symbol-keyed properties were silently dropped in both sync and async object-expression evaluation.

## Changes

- Added shared object-spread copy logic that iterates `Reflect.ownKeys(...)` and skips non-enumerable properties.
- Preserved prototype-pollution validation for string keys.
- Updated object memory accounting to include symbol keys.
- Added sync and async regression tests for mixed string and symbol object spread.
- Added a patch changeset.

## Validation

- `bun fmt`
- `bun lint:fix` (passes with existing warnings only)
- `bun test`
- `bun typecheck`