### PR TITLE
fix: preserve symbol keys in object rest destructuring

### DIFF
--- a/.changeset/quiet-symbols-rest.md
+++ b/.changeset/quiet-symbols-rest.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Preserve enumerable symbol-keyed properties in object rest destructuring.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -8646,12 +8646,16 @@ export class Interpreter {
     // Second pass: Handle rest element if present
     if (restElement) {
       const restName = this.getRestElementName(restElement);
-      const restObj: Record<string, any> = this.markSandboxContainer({});
+      const restObj: Record<PropertyKey, any> = this.markSandboxContainer({});
 
       // Collect all non-destructured properties
-      for (const [key, val] of Object.entries(value)) {
-        if (!destructuredKeys.has(key)) {
-          validatePropertyName(key); // Security: prevent prototype pollution
+      for (const key of Reflect.ownKeys(value)) {
+        if (!destructuredKeys.has(key) && Object.prototype.propertyIsEnumerable.call(value, key)) {
+          if (typeof key === "string") {
+            validatePropertyName(key); // Security: prevent prototype pollution
+          }
+
+          const val = value[key];
           restObj[key] = val;
         }
       }
@@ -11923,12 +11927,16 @@ export class Interpreter {
     // Second pass: Handle rest element if present
     if (restElement) {
       const restName = this.getRestElementName(restElement);
-      const restObj: Record<string, any> = this.markSandboxContainer({});
+      const restObj: Record<PropertyKey, any> = this.markSandboxContainer({});
 
       // Collect all non-destructured properties
-      for (const [key, val] of Object.entries(value)) {
-        if (!destructuredKeys.has(key)) {
-          validatePropertyName(key); // Security: prevent prototype pollution
+      for (const key of Reflect.ownKeys(value)) {
+        if (!destructuredKeys.has(key) && Object.prototype.propertyIsEnumerable.call(value, key)) {
+          if (typeof key === "string") {
+            validatePropertyName(key); // Security: prevent prototype pollution
+          }
+
+          const val = value[key];
           restObj[key] = val;
         }
       }

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -8653,6 +8653,8 @@ export class Interpreter {
         if (!destructuredKeys.has(key) && Object.prototype.propertyIsEnumerable.call(value, key)) {
           if (typeof key === "string") {
             validatePropertyName(key); // Security: prevent prototype pollution
+          } else {
+            this.validateSymbolProperty(key);
           }
 
           const val = value[key];
@@ -11934,6 +11936,8 @@ export class Interpreter {
         if (!destructuredKeys.has(key) && Object.prototype.propertyIsEnumerable.call(value, key)) {
           if (typeof key === "string") {
             validatePropertyName(key); // Security: prevent prototype pollution
+          } else {
+            this.validateSymbolProperty(key);
           }
 
           const val = value[key];

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -526,6 +526,36 @@ describe("Security", () => {
         }).toThrow("Symbol 'Symbol(Symbol.toStringTag)' is not allowed for security reasons");
       });
 
+      it("should block dangerous symbol access through object rest destructuring", () => {
+        const sym = Symbol.toStringTag;
+        const interpreter = new Interpreter({
+          globals: { sym },
+        });
+        expect(() => {
+          interpreter.evaluate(`
+            const box = { [sym]: "secret", a: 1 };
+            const { a, ...rest } = box;
+            rest;
+          `);
+        }).toThrow("Symbol 'Symbol(Symbol.toStringTag)' is not allowed for security reasons");
+      });
+
+      it("should block dangerous symbol access through object rest destructuring in async evaluation", () => {
+        const sym = Symbol.toStringTag;
+        const interpreter = new Interpreter({
+          globals: { sym },
+        });
+        return expect(
+          interpreter.evaluateAsync(`
+            const box = { [sym]: "secret", a: 1 };
+            const { a, ...rest } = box;
+            rest;
+          `),
+        ).rejects.toThrow(
+          "Symbol 'Symbol(Symbol.toStringTag)' is not allowed for security reasons",
+        );
+      });
+
       it("should block dangerous symbol access in update expressions", () => {
         const sym = Symbol.toPrimitive;
         const interpreter = new Interpreter({

--- a/test/variables.test.ts
+++ b/test/variables.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, test, expect, beforeEach } from "bun:test";
 
 import { Interpreter, InterpreterError } from "../src/interpreter";
+import { ES2024 } from "../src/presets";
 
 describe("Variables", () => {
   describe("ES5", () => {
@@ -2406,6 +2407,44 @@ describe("Variables", () => {
             rest;
           `);
           expect(result).toEqual({ b: 2, c: 3 });
+        });
+
+        it("should preserve enumerable symbol keys in rest objects", () => {
+          const interpreter = new Interpreter(ES2024);
+          const result = interpreter.evaluate(`
+            const sym = Symbol("metadata");
+            const hidden = Symbol("hidden");
+            const source = { [sym]: 123, a: 1, b: 2 };
+            Object.defineProperty(source, hidden, { value: 456, enumerable: false });
+            const {a, ...rest} = source;
+            [rest[sym], Object.getOwnPropertySymbols(rest).length, rest.b];
+          `);
+          expect(result).toEqual([123, 1, 2]);
+        });
+
+        it("should exclude destructured symbol keys from rest objects", () => {
+          const interpreter = new Interpreter(ES2024);
+          const result = interpreter.evaluate(`
+            const keep = Symbol("keep");
+            const omit = Symbol("omit");
+            const source = { [keep]: 123, [omit]: 456, a: 1 };
+            const {[omit]: value, ...rest} = source;
+            [value, rest[keep], rest[omit], Object.getOwnPropertySymbols(rest).length, rest.a];
+          `);
+          expect(result).toEqual([456, 123, undefined, 1, 1]);
+        });
+
+        it("should preserve enumerable symbol keys in rest objects in evaluateAsync", async () => {
+          const interpreter = new Interpreter(ES2024);
+          const result = await interpreter.evaluateAsync(`
+            const sym = Symbol("metadata");
+            const hidden = Symbol("hidden");
+            const source = { [sym]: 123, a: 1, b: 2 };
+            Object.defineProperty(source, hidden, { value: 456, enumerable: false });
+            const {a, ...rest} = source;
+            [rest[sym], Object.getOwnPropertySymbols(rest).length, rest.b];
+          `);
+          expect(result).toEqual([123, 1, 2]);
         });
       });
 


### PR DESCRIPTION
## Summary

Fixes #204.

Object rest destructuring now copies enumerable own keys with `Reflect.ownKeys(...)` instead of `Object.entries(...)`, so remaining enumerable symbol-keyed properties are preserved. String keys still go through the existing property-name validation to keep prototype-pollution protections intact.

This updates both the sync and async object destructuring paths so their behavior stays aligned.

## Changes

- Preserve enumerable symbol-keyed properties when building object rest bindings.
- Continue excluding computed symbol keys that were explicitly destructured.
- Skip non-enumerable symbol keys, matching object rest semantics.
- Add regression coverage for sync and async object rest destructuring.
- Add a patch changeset.

## Verification

- `bun fmt`
- `bun lint:fix` completed with 5 existing warnings and 0 errors
- `bun test test/variables.test.ts`
- `bun test` passed: 3681 pass, 0 fail
- `bun typecheck`