### PR TITLE
[codex] Fix ReadOnlyProxy descriptor reflection for wrapped host globals

### DIFF
--- a/.changeset/famous-cameras-jam.md
+++ b/.changeset/famous-cameras-jam.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Fix `ReadOnlyProxy` descriptor reflection so wrapped host globals expose read-only descriptor semantics and wrapped descriptor payloads.

--- a/src/readonly-proxy.ts
+++ b/src/readonly-proxy.ts
@@ -114,6 +114,19 @@ function shouldUnwrapAllowlistedTarget(
   return false;
 }
 
+function shouldUseShadowTarget(value: unknown): value is object {
+  if (value === null || typeof value !== "object") {
+    return false;
+  }
+
+  if (Array.isArray(value) || isTypedArray(value)) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
 /**
  * Unwrap a value for passing to native host functions.
  *
@@ -474,23 +487,26 @@ export class ReadOnlyProxy {
       return cachedProxy;
     }
 
+    const realTarget = value;
+    const proxyTarget = shouldUseShadowTarget(realTarget) ? Object.create(null) : realTarget;
+
     // Create a proxy that intercepts all operations (for objects like Math, console, etc.)
-    const proxy = new Proxy(value, {
-      get(target, prop, _receiver) {
+    const proxy = new Proxy(proxyTarget, {
+      get(_target, prop, _receiver) {
         // Allow retrieving the underlying target for instanceof checks
         if (prop === PROXY_TARGET) {
-          return target;
+          return realTarget;
         }
         if (prop === PROXY_NAME) {
           return name;
         }
 
         if (prop === Symbol.iterator || prop === Symbol.asyncIterator) {
-          const iterator = Reflect.get(target, prop, target);
+          const iterator = Reflect.get(realTarget, prop, realTarget);
           if (typeof iterator === "function") {
             return () =>
               ReadOnlyProxy.wrapIterator(
-                iterator.call(target),
+                iterator.call(realTarget),
                 name,
                 prop === Symbol.asyncIterator,
                 securityOptions,
@@ -512,23 +528,27 @@ export class ReadOnlyProxy {
         if (prop === "valueOf") {
           return () => {
             // For primitive wrapper objects (Number, String, Boolean), return the primitive
-            if (target instanceof Number || target instanceof String || target instanceof Boolean) {
+            if (
+              realTarget instanceof Number ||
+              realTarget instanceof String ||
+              realTarget instanceof Boolean
+            ) {
               // These are safe to call - they just return the wrapped primitive
-              return target.valueOf();
+              return realTarget.valueOf();
             }
             // For Date objects, return the timestamp (standard behavior)
-            if (target instanceof Date) {
-              return target.valueOf();
+            if (realTarget instanceof Date) {
+              return realTarget.valueOf();
             }
             // For all other objects, return the wrapped object itself
             // This is the standard Object.prototype.valueOf behavior
-            return ReadOnlyProxy.wrap(target, name, securityOptions, ecmaVersion);
+            return ReadOnlyProxy.wrap(realTarget, name, securityOptions, ecmaVersion);
           };
         }
 
         // Special handling for Error.stack - sanitize to remove host paths
         if (isError && prop === "stack") {
-          const stack = Reflect.get(target, prop, target);
+          const stack = Reflect.get(realTarget, prop, realTarget);
           if (effectiveOptions.sanitizeErrors) {
             return sanitizeErrorStack(stack);
           }
@@ -540,16 +560,19 @@ export class ReadOnlyProxy {
           throw new InterpreterError(`Cannot access ${String(prop)} on global '${name}'`);
         }
 
-        if (!isEcmaBuiltinStaticPropertyAvailable(name, target, prop, ecmaVersion)) {
+        if (!isEcmaBuiltinStaticPropertyAvailable(name, realTarget, prop, ecmaVersion)) {
           return undefined;
         }
 
         // Get the actual value
-        const val = Reflect.get(target, prop, target); // Use target as receiver to preserve 'this'
+        const val = Reflect.get(realTarget, prop, realTarget); // Use target as receiver to preserve 'this'
 
         // If it's a function, wrap it as HostFunctionValue
         if (typeof val === "function") {
-          const methodWrapperCache = ReadOnlyProxy.getMethodWrapperCache(effectiveOptions, target);
+          const methodWrapperCache = ReadOnlyProxy.getMethodWrapperCache(
+            effectiveOptions,
+            realTarget,
+          );
           const cachedMethodWrapper = methodWrapperCache.get(prop);
           if (cachedMethodWrapper && cachedMethodWrapper.fn === val) {
             return cachedMethodWrapper.wrapper;
@@ -562,7 +585,7 @@ export class ReadOnlyProxy {
             (...args: any[]) => {
               // Call with target as 'this' to preserve method binding
               // Example: Math.floor.call(Math, 4.7) should work
-              return val.apply(target, args);
+              return val.apply(realTarget, args);
             },
             `${name}.${String(prop)}`,
             isAsync,
@@ -584,14 +607,14 @@ export class ReadOnlyProxy {
         return val;
       },
 
-      set(target, prop, value) {
+      set(_target, prop, value) {
         // Allow element mutation on TypedArrays via numeric indices
         // TypedArrays need to be writable for common use cases like encoder.encodeInto()
-        if (isTypedArray(target)) {
+        if (isTypedArray(realTarget)) {
           // Allow numeric index writes (element mutation)
           const index = typeof prop === "string" ? Number(prop) : prop;
           if (typeof index === "number" && Number.isInteger(index) && index >= 0) {
-            (target as any)[prop] = value;
+            (realTarget as any)[prop] = value;
             return true;
           }
         }
@@ -603,14 +626,14 @@ export class ReadOnlyProxy {
         );
       },
 
-      deleteProperty(target, prop) {
+      deleteProperty(_target, prop) {
         throw new InterpreterError(
           `Cannot delete property '${String(prop)}' from global '${name}' (read-only)`,
         );
       },
 
       // Block defineProperty to prevent property descriptor manipulation
-      defineProperty(target, prop) {
+      defineProperty(_target, prop) {
         throw new InterpreterError(
           `Cannot define property '${String(prop)}' on global '${name}' (read-only)`,
         );
@@ -634,32 +657,88 @@ export class ReadOnlyProxy {
         if (isDangerousProperty(prop)) {
           return undefined;
         }
-        if (!isEcmaBuiltinStaticPropertyAvailable(name, target, prop, ecmaVersion)) {
+        if (!isEcmaBuiltinStaticPropertyAvailable(name, realTarget, prop, ecmaVersion)) {
           return undefined;
         }
-        return Reflect.getOwnPropertyDescriptor(target, prop);
+        const descriptor = Reflect.getOwnPropertyDescriptor(realTarget, prop);
+        if (!descriptor) {
+          return undefined;
+        }
+        if (target !== realTarget) {
+          const shadowDescriptor = Reflect.getOwnPropertyDescriptor(target, prop);
+          if (shadowDescriptor) {
+            return shadowDescriptor;
+          }
+        }
+
+        const wrappedDescriptorValue =
+          "value" in descriptor
+            ? ReadOnlyProxy.wrap(
+                descriptor.value,
+                `${name}.${String(prop)}`,
+                securityOptions,
+                ecmaVersion,
+              )
+            : undefined;
+        const wrappedGetter = descriptor.get
+          ? () =>
+              ReadOnlyProxy.wrap(
+                Reflect.apply(descriptor.get as () => unknown, realTarget, []),
+                `${name}.${String(prop)}`,
+                securityOptions,
+                ecmaVersion,
+              )
+          : undefined;
+
+        const normalizedDescriptor = {
+          configurable: target === realTarget ? (descriptor.configurable ?? false) : false,
+          enumerable: descriptor.enumerable ?? false,
+          ...(descriptor.get || descriptor.set
+            ? {
+                get: wrappedGetter,
+                set: undefined,
+              }
+            : {
+                value: wrappedDescriptorValue,
+                writable: target === realTarget ? (descriptor.writable ?? false) : false,
+              }),
+        };
+
+        if (target !== realTarget && !Reflect.has(target, prop)) {
+          const shadowDescriptor =
+            descriptor.get || descriptor.set
+              ? {
+                  configurable: false,
+                  enumerable: descriptor.enumerable ?? false,
+                  ...(wrappedGetter ? { get: wrappedGetter } : {}),
+                }
+              : normalizedDescriptor;
+          Reflect.defineProperty(target, prop, shadowDescriptor);
+        }
+
+        return normalizedDescriptor;
       },
 
       // Allow has operator (prop in obj)
-      has(target, prop) {
+      has(_target, prop) {
         // Block dangerous properties
         if (isDangerousProperty(prop)) {
           return false;
         }
-        if (!isEcmaBuiltinStaticPropertyAvailable(name, target, prop, ecmaVersion)) {
+        if (!isEcmaBuiltinStaticPropertyAvailable(name, realTarget, prop, ecmaVersion)) {
           return false;
         }
-        return Reflect.has(target, prop);
+        return Reflect.has(realTarget, prop);
       },
 
       // Allow ownKeys (Object.keys, Object.getOwnPropertyNames, etc.)
-      ownKeys(target) {
-        const keys = Reflect.ownKeys(target);
+      ownKeys(_target) {
+        const keys = Reflect.ownKeys(realTarget);
         // Filter out dangerous properties
         return keys.filter(
           (key) =>
             !isDangerousProperty(key) &&
-            isEcmaBuiltinStaticPropertyAvailable(name, target, key, ecmaVersion),
+            isEcmaBuiltinStaticPropertyAvailable(name, realTarget, key, ecmaVersion),
         );
       },
     });

--- a/src/readonly-proxy.ts
+++ b/src/readonly-proxy.ts
@@ -122,9 +122,7 @@ function shouldUseShadowTarget(value: unknown): value is object {
   if (Array.isArray(value) || isTypedArray(value)) {
     return false;
   }
-
-  const prototype = Object.getPrototypeOf(value);
-  return prototype === Object.prototype || prototype === null;
+  return true;
 }
 
 /**
@@ -710,7 +708,8 @@ export class ReadOnlyProxy {
               ? {
                   configurable: false,
                   enumerable: descriptor.enumerable ?? false,
-                  ...(wrappedGetter ? { get: wrappedGetter } : {}),
+                  get: wrappedGetter,
+                  set: undefined,
                 }
               : normalizedDescriptor;
           Reflect.defineProperty(target, prop, shadowDescriptor);

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -2034,6 +2034,51 @@ describe("Security", () => {
         expect(nestedDescriptorValue?.value).toBe(1);
       });
 
+      it("should not violate descriptor invariants for non-plain host objects", () => {
+        class HostBox {
+          child = { value: 1 };
+        }
+
+        const host = new HostBox();
+        Object.defineProperty(host, "child", {
+          value: host.child,
+          writable: false,
+          configurable: false,
+          enumerable: true,
+        });
+
+        const wrapped = ReadOnlyProxy.wrap(host, "box");
+
+        const descriptor = Object.getOwnPropertyDescriptor(wrapped, "child");
+        const descriptorValue = descriptor?.value as { value: number } | undefined;
+
+        expect(descriptor).toBeDefined();
+        expect(descriptor?.writable).toBe(false);
+        expect(descriptor?.configurable).toBe(false);
+        expect(descriptorValue).not.toBe(host.child);
+        expect(descriptorValue?.value).toBe(1);
+      });
+
+      it("should keep setter-only descriptors accessor-shaped across repeated reads", () => {
+        const host = {};
+        Object.defineProperty(host, "writeOnly", {
+          set(_value: unknown) {},
+          configurable: true,
+          enumerable: true,
+        });
+
+        const wrapped = ReadOnlyProxy.wrap(host, "obj");
+
+        const firstDescriptor = Object.getOwnPropertyDescriptor(wrapped, "writeOnly");
+        const secondDescriptor = Object.getOwnPropertyDescriptor(wrapped, "writeOnly");
+
+        expect(firstDescriptor).toBeDefined();
+        expect(firstDescriptor?.get === undefined).toBe(true);
+        expect(firstDescriptor?.set === undefined).toBe(true);
+        expect("value" in (firstDescriptor ?? {})).toBe(false);
+        expect(secondDescriptor).toEqual(firstDescriptor);
+      });
+
       it("should block setting properties", () => {
         const testObj = { value: 42 };
         const wrapped = ReadOnlyProxy.wrap(testObj, "obj");

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -1998,6 +1998,42 @@ describe("Security", () => {
     });
 
     describe("Property modification protection via proxy", () => {
+      it("should expose read-only descriptor metadata for wrapped host properties", () => {
+        const nested = { value: 1 };
+        const wrapped = ReadOnlyProxy.wrap({ nested }, "obj");
+
+        const descriptor = Object.getOwnPropertyDescriptor(wrapped, "nested");
+        const descriptorValue = descriptor?.value as { value: number } | undefined;
+
+        expect(descriptor).toBeDefined();
+        expect(descriptor?.writable).toBe(false);
+        expect(descriptor?.configurable).toBe(false);
+        expect(descriptor?.enumerable).toBe(true);
+        expect(descriptorValue).not.toBe(nested);
+        expect(descriptorValue?.value).toBe(1);
+        expect(() => {
+          if (!descriptorValue) {
+            throw new Error("Expected descriptor value");
+          }
+          descriptorValue.value = 2;
+        }).toThrow("Cannot modify property 'value' on global 'obj.nested' (read-only)");
+      });
+
+      it("should expose consistent read-only descriptors through Object.getOwnPropertyDescriptors", () => {
+        const nested = { value: 1 };
+        const wrapped = ReadOnlyProxy.wrap({ nested }, "obj");
+
+        const descriptors = Object.getOwnPropertyDescriptors(wrapped);
+        const nestedDescriptorValue = descriptors.nested?.value as { value: number } | undefined;
+
+        expect(descriptors.nested).toBeDefined();
+        expect(descriptors.nested?.writable).toBe(false);
+        expect(descriptors.nested?.configurable).toBe(false);
+        expect(descriptors.nested?.enumerable).toBe(true);
+        expect(nestedDescriptorValue).not.toBe(nested);
+        expect(nestedDescriptorValue?.value).toBe(1);
+      });
+
       it("should block setting properties", () => {
         const testObj = { value: 42 };
         const wrapped = ReadOnlyProxy.wrap(testObj, "obj");


### PR DESCRIPTION
## Summary
- align `ReadOnlyProxy` descriptor reflection with sandbox-visible read-only behavior for wrapped plain host objects
- wrap descriptor `value` payloads and accessor reads before exposing them through reflective APIs
- add regression coverage for `Object.getOwnPropertyDescriptor(...)` and `Object.getOwnPropertyDescriptors(...)`
- include a patch changeset for the fix

## Why
Issue #205 reports that reflective descriptor APIs exposed host descriptors that claimed wrapped globals were writable/configurable even though the sandbox rejects writes. The existing trap also forwarded raw descriptor payloads, which meant reflective reads could observe unwrapped host values.

## Root Cause
`ReadOnlyProxy.getOwnPropertyDescriptor` forwarded `Reflect.getOwnPropertyDescriptor(target, prop)` directly. That leaked the host descriptor flags and payload unchanged, so descriptor metadata diverged from the sandbox's enforced read-only semantics.

## What Changed
- use a shadow proxy target for wrapped plain objects so descriptor reflection can report read-only descriptors without mutating the underlying host object
- normalize reflected descriptors for those shadow-targeted objects to read-only metadata
- preserve proxy invariant compatibility by caching shadow descriptors for repeated reflective reads
- keep non-plain object wrappers compatible with native proxy invariants while still wrapping descriptor payloads
- add regression tests that verify both descriptor flags and wrapped payload behavior

## Developer Impact
Reflective code running against wrapped plain host globals now sees descriptor metadata that matches the sandbox surface, and descriptor values no longer hand out raw host references.

## Validation
- `bun fmt`
- `bun run lint:fix`
- `bun run typecheck`
- `bun test`

Closes #205