### PR TITLE
[codex] Retry failed cached modules

### DIFF
--- a/.changeset/soft-falcons-retry.md
+++ b/.changeset/soft-falcons-retry.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Evict failed module records so cached resolvers can retry transient module evaluation failures.

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -390,6 +390,12 @@ await sandbox.runModule('import { x } from "mod.js";', { path: "a.js" });
 await sandbox.runModule('import { x } from "mod.js";', { path: "b.js" });
 ```
 
+Only successfully evaluated modules are retained in the cache. If resolution returns
+a source but evaluation fails, NookJS evicts that failed record so a later import of
+the same path can call the resolver again and recover from transient source,
+network, or storage failures. In-progress records are still reused while evaluating
+circular dependencies.
+
 ### Cache Control
 
 ```typescript
@@ -398,6 +404,9 @@ const sandbox = createSandbox({
   env: "es2022",
   modules: { resolver, cache: false },
 });
+
+// With cache disabled, both successful and failed imports are resolved and
+// evaluated again on each import attempt.
 
 // For programmatic cache management, use the internal Interpreter API
 // (see docs/INTERNAL_CLASSES.md).

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -51,6 +51,13 @@ class ResolutionContextPathCache {
     this.deleteEntry(entry);
   }
 
+  deleteByPath(path: string): void {
+    const matchingEntries = Array.from(this.lruEntries).filter((entry) => entry.path === path);
+    for (const entry of matchingEntries) {
+      this.deleteEntry(entry);
+    }
+  }
+
   get(
     specifier: string,
     importer: string | null,
@@ -757,7 +764,7 @@ export class ModuleSystem {
       record.error = error;
       this.cacheByPath.delete(path);
       this.unregisterPath(path);
-      this.resolvedPathByContext.clear();
+      this.resolvedPathByContext.deleteByPath(path);
       this.options.resolver.onError?.(record.specifier, record.importer, error);
     }
   }

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -481,6 +481,28 @@ export class ModuleSystem {
     importerPaths.add(path);
   }
 
+  private unregisterPath(path: string): void {
+    for (const [specifier, paths] of this.specifierToPaths) {
+      paths.delete(path);
+      if (paths.size === 0) {
+        this.specifierToPaths.delete(specifier);
+      }
+    }
+
+    for (const [specifier, pathsByImporter] of this.specifierToPathsByImporter) {
+      for (const [importer, paths] of pathsByImporter) {
+        paths.delete(path);
+        if (paths.size === 0) {
+          pathsByImporter.delete(importer);
+        }
+      }
+
+      if (pathsByImporter.size === 0) {
+        this.specifierToPathsByImporter.delete(specifier);
+      }
+    }
+  }
+
   private getUnambiguousPath(paths?: ReadonlySet<string>): string | undefined {
     if (!paths || paths.size !== 1) {
       return undefined;
@@ -608,10 +630,6 @@ export class ModuleSystem {
           if (existingByPath.status === "initializing") {
             return existingByPath;
           }
-          // If previously failed, return cached failure record
-          if (existingByPath.status === "failed") {
-            return existingByPath;
-          }
         }
       }
 
@@ -730,13 +748,16 @@ export class ModuleSystem {
   }
 
   /**
-   * Mark a module as failed.
+   * Mark a module as failed and evict it so the next import can retry.
    */
   setModuleFailed(path: string, error: Error): void {
     const record = this.cacheByPath.get(path);
     if (record) {
       record.status = "failed";
       record.error = error;
+      this.cacheByPath.delete(path);
+      this.unregisterPath(path);
+      this.resolvedPathByContext.clear();
       this.options.resolver.onError?.(record.specifier, record.importer, error);
     }
   }

--- a/test/modules.test.ts
+++ b/test/modules.test.ts
@@ -576,6 +576,49 @@ describe("Module System", () => {
       expect(exports?.value).toBe(42);
     });
 
+    test("should retry cached module path after evaluation failure", async () => {
+      const state = { shouldFail: true, resolveCount: 0 };
+
+      const resolver: ModuleResolver = {
+        resolve(specifier) {
+          state.resolveCount++;
+          return {
+            type: "source",
+            code: state.shouldFail
+              ? 'throw "temporary failure";'
+              : 'export const value = "recovered";',
+            path: specifier,
+          };
+        },
+      };
+
+      const interpreter = new Interpreter({
+        modules: { enabled: true, resolver, cache: true },
+      });
+
+      try {
+        await interpreter.evaluateModuleAsync('import { value } from "transient.js";', {
+          path: "main1.js",
+        });
+        throw new Error("Expected transient module import to fail");
+      } catch (error) {
+        expect((error as Error).message).toContain("temporary failure");
+      }
+
+      expect(interpreter.isModuleCached("transient.js")).toBe(false);
+      expect(interpreter.isModuleCachedByPath("transient.js")).toBe(false);
+
+      state.shouldFail = false;
+      const result = await interpreter.evaluateModuleAsync(
+        'import { value } from "transient.js"; export const output = value;',
+        { path: "main2.js" },
+      );
+
+      expect(result.output).toBe("recovered");
+      expect(state.resolveCount).toBe(2);
+      expect(interpreter.getModuleMetadata("transient.js")?.status).toBe("initialized");
+    });
+
     test("should provide module introspection API", async () => {
       const resolver: ModuleResolver = {
         resolve(specifier) {
@@ -3287,8 +3330,8 @@ describe("Module System", () => {
       expect(interpreter.getModuleExportsBySpecifier("nonexistent.js")).toBeUndefined();
     });
 
-    test("should track failed module in metadata", async () => {
-      let badModuleEvaluations = 0;
+    test("should evict failed module metadata and retry on next import", async () => {
+      const state = { badModuleEvaluations: 0 };
       const resolver: ModuleResolver = {
         resolve(specifier) {
           if (specifier === "bad.js") {
@@ -3305,8 +3348,8 @@ describe("Module System", () => {
       const interpreter = new Interpreter({
         globals: {
           bump: () => {
-            badModuleEvaluations += 1;
-            return badModuleEvaluations;
+            state.badModuleEvaluations += 1;
+            return state.badModuleEvaluations;
           },
         },
         modules: { enabled: true, resolver },
@@ -3325,11 +3368,9 @@ describe("Module System", () => {
         firstError instanceof Error ? firstError.message : String(firstError);
       expect(firstErrorMessage).toContain("Undefined variable 'nope'");
 
-      const metadata = interpreter.getModuleMetadata("bad.js");
-      expect(metadata).toBeDefined();
-      expect(metadata?.status).toBe("failed");
-      expect(metadata?.error).toBeDefined();
-      expect(badModuleEvaluations).toBe(1);
+      expect(interpreter.getModuleMetadata("bad.js")).toBeUndefined();
+      expect(interpreter.isModuleCached("bad.js")).toBe(false);
+      expect(state.badModuleEvaluations).toBe(1);
 
       let secondError: unknown;
       try {
@@ -3340,7 +3381,7 @@ describe("Module System", () => {
         secondError = error;
       }
       expect(secondError).toBeDefined();
-      expect(badModuleEvaluations).toBe(1);
+      expect(state.badModuleEvaluations).toBe(2);
     });
 
     test("should preserve importer attribution for failed module onError callbacks", async () => {

--- a/test/modules.test.ts
+++ b/test/modules.test.ts
@@ -4567,6 +4567,51 @@ describe("Module System", () => {
       expect(resolutionContextStringifyCount).toBe(0);
     });
 
+    test("should preserve unrelated resolved-path context entries when a module fails", async () => {
+      const state = { failingShouldThrow: true, stableResolveCount: 0 };
+      const moduleSystem = new ModuleSystem({
+        enabled: true,
+        cache: true,
+        resolver: {
+          resolve(specifier) {
+            if (specifier === "./stable") {
+              state.stableResolveCount += 1;
+              return {
+                type: "namespace",
+                exports: { value: 1 },
+                path: "/stable.js",
+              };
+            }
+            if (specifier === "./failing") {
+              return {
+                type: "source",
+                code: state.failingShouldThrow
+                  ? 'throw "temporary failure";'
+                  : 'export const value = "recovered";',
+                path: "/failing.js",
+              };
+            }
+            return null;
+          },
+        },
+      });
+      const internalModuleSystem = moduleSystem as unknown as {
+        resolvedPathByContext: { size: number };
+      };
+
+      await moduleSystem.resolveModule("./stable", "main.js");
+      const failingRecord = await moduleSystem.resolveModule("./failing", "main.js");
+      expect(internalModuleSystem.resolvedPathByContext.size).toBe(2);
+      expect(failingRecord?.path).toBe("/failing.js");
+
+      moduleSystem.setModuleFailed("/failing.js", new Error("temporary failure"));
+
+      expect(internalModuleSystem.resolvedPathByContext.size).toBe(1);
+      await moduleSystem.resolveModule("./stable", "main.js");
+
+      expect(state.stableResolveCount).toBe(1);
+    });
+
     test("should handle path aliasing correctly for allowed imports", async () => {
       const resolver: ModuleResolver = {
         resolve(specifier) {


### PR DESCRIPTION
## Summary

Fixes #206 by evicting module records when evaluation fails instead of leaving a failed record in the module cache. This lets cache-enabled resolvers recover from transient source, network, or storage failures on a later import of the same path.

## Root Cause

`setModuleFailed()` marked cached records as `failed`, and `resolveModule()` returned those failed records on subsequent imports. Because the resolved path context cache and specifier indexes still pointed at the failed path, callers could not recover without clearing the entire module cache.

## Changes

- Evict failed module records from `cacheByPath` during `setModuleFailed()`.
- Remove failed paths from specifier introspection indexes and clear resolved-path fast-path entries.
- Preserve initialized cache reuse and initializing record reuse for circular dependencies.
- Add regression coverage for fail-then-succeed imports and update failed-module metadata expectations.
- Document cache behavior for successful, failed, and cache-disabled module imports.
- Add a patch changeset.

## Validation

- `bun fmt`
- `bun lint:fix` (passes with existing warnings)
- `bun test` (3688 pass)
- `bun typecheck`