### PR TITLE
[codex] Bound module cache entries

### DIFF
--- a/.changeset/bounded-module-cache.md
+++ b/.changeset/bounded-module-cache.md
@@ -1,0 +1,5 @@
+---
+"nookjs": minor
+---
+
+Add an optional `maxEntries` module cache bound with LRU eviction for long-lived sandboxes.

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -61,6 +61,7 @@ const sandbox = createSandbox({
     resolver,
     maxDepth: 100, // Optional: max import depth (default: 100)
     cache: true, // Optional: enable caching (default: true)
+    maxEntries: 1000, // Optional: bound retained module records (default: unbounded)
   },
 });
 ```
@@ -407,6 +408,14 @@ const sandbox = createSandbox({
 
 // With cache disabled, both successful and failed imports are resolved and
 // evaluated again on each import attempt.
+
+// Bound cache growth for long-lived sandboxes. When the cache exceeds maxEntries,
+// the least recently used initialized module is evicted and specifier/importer
+// indexes are cleaned up with it.
+const boundedSandbox = createSandbox({
+  env: "es2022",
+  modules: { resolver, maxEntries: 1000 },
+});
 
 // For programmatic cache management, use the internal Interpreter API
 // (see docs/INTERNAL_CLASSES.md).

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -320,6 +320,7 @@ export interface ModuleOptions {
   enabled: boolean;
   resolver: ModuleResolver;
   cache?: boolean;
+  maxEntries?: number;
   maxDepth?: number;
 }
 
@@ -399,6 +400,7 @@ export class ModuleSystem {
     MAX_RESOLVED_PATH_CONTEXT_CACHE_SIZE,
   );
   private options: ModuleOptions;
+  private readonly maxEntries: number;
   // Track depth per evaluation context using a stack (fixes shared depth counter)
   private evaluationStack: string[] = [];
 
@@ -409,6 +411,7 @@ export class ModuleSystem {
       cache: options.cache ?? true,
       maxDepth: options.maxDepth ?? 100,
     };
+    this.maxEntries = this.normalizeMaxEntries(this.options.maxEntries);
   }
 
   /**
@@ -486,6 +489,51 @@ export class ModuleSystem {
       pathsByImporter.set(importer, importerPaths);
     }
     importerPaths.add(path);
+  }
+
+  private normalizeMaxEntries(maxEntries: number | undefined): number {
+    if (maxEntries === undefined) {
+      return Infinity;
+    }
+
+    if (!Number.isFinite(maxEntries) || maxEntries < 0) {
+      throw new Error("Module cache maxEntries must be a non-negative finite number");
+    }
+
+    return Math.floor(maxEntries);
+  }
+
+  private touchModuleRecord(path: string): void {
+    const record = this.cacheByPath.get(path);
+    if (!record) {
+      return;
+    }
+
+    this.cacheByPath.delete(path);
+    this.cacheByPath.set(path, record);
+  }
+
+  private evictModulePath(path: string): void {
+    this.cacheByPath.delete(path);
+    this.unregisterPath(path);
+    this.resolvedPathByContext.deleteByPath(path);
+  }
+
+  private evictOldestModuleIfNeeded(): void {
+    if (this.cacheByPath.size <= this.maxEntries) {
+      return;
+    }
+
+    for (const [path, record] of this.cacheByPath) {
+      if (record.status === "initializing") {
+        continue;
+      }
+
+      this.evictModulePath(path);
+      if (this.cacheByPath.size <= this.maxEntries) {
+        return;
+      }
+    }
   }
 
   private unregisterPath(path: string): void {
@@ -595,6 +643,7 @@ export class ModuleSystem {
               context.importerChain,
               cachedPath,
             );
+            this.touchModuleRecord(cachedPath);
             return existingByPath;
           }
 
@@ -629,6 +678,7 @@ export class ModuleSystem {
           // resolve to a module path that is already cached.
           this.registerSpecifierPath(specifier, importer, source.path);
           this.cacheResolvedPathForContext(specifier, importer, context.importerChain, source.path);
+          this.touchModuleRecord(source.path);
           // If already initialized, return cached exports
           if (existingByPath.status === "initialized") {
             return existingByPath;
@@ -664,6 +714,7 @@ export class ModuleSystem {
         this.cacheByPath.set(source.path, record);
         this.registerSpecifierPath(specifier, importer, source.path);
         this.cacheResolvedPathForContext(specifier, importer, context.importerChain, source.path);
+        this.evictOldestModuleIfNeeded();
       }
 
       if (source.type === "namespace") {
@@ -673,6 +724,7 @@ export class ModuleSystem {
         // causes issues with proxy wrapping
         record.exports = shallowCloneWithDescriptors(source.exports);
         record.status = "initialized";
+        this.evictOldestModuleIfNeeded();
         this.options.resolver.onLoad?.(specifier, source.path, record.exports);
         return record;
       }
@@ -733,6 +785,8 @@ export class ModuleSystem {
       // Exports are already protected by ReadOnlyProxy from evaluateModuleAstAsync
       record.exports = exports;
       record.status = "initialized";
+      this.touchModuleRecord(path);
+      this.evictOldestModuleIfNeeded();
       this.options.resolver.onLoad?.(record.specifier, path, record.exports);
     }
   }
@@ -762,9 +816,7 @@ export class ModuleSystem {
     if (record) {
       record.status = "failed";
       record.error = error;
-      this.cacheByPath.delete(path);
-      this.unregisterPath(path);
-      this.resolvedPathByContext.deleteByPath(path);
+      this.evictModulePath(path);
       this.options.resolver.onError?.(record.specifier, record.importer, error);
     }
   }

--- a/src/modules.ts
+++ b/src/modules.ts
@@ -395,6 +395,8 @@ export class ModuleSystem {
   private specifierToPaths: Map<string, Set<string>> = new Map();
   // Importer-aware index used by public introspection when a specifier is context-sensitive.
   private specifierToPathsByImporter: Map<string, Map<string | null, Set<string>>> = new Map();
+  private pathToSpecifiers: Map<string, Set<string>> = new Map();
+  private pathToSpecifierImporters: Map<string, Map<string, Set<string | null>>> = new Map();
   // Context-specific index for reusing cached module paths without re-running resolve()
   private resolvedPathByContext = new ResolutionContextPathCache(
     MAX_RESOLVED_PATH_CONTEXT_CACHE_SIZE,
@@ -489,6 +491,26 @@ export class ModuleSystem {
       pathsByImporter.set(importer, importerPaths);
     }
     importerPaths.add(path);
+
+    let specifiers = this.pathToSpecifiers.get(path);
+    if (!specifiers) {
+      specifiers = new Set();
+      this.pathToSpecifiers.set(path, specifiers);
+    }
+    specifiers.add(specifier);
+
+    let importersBySpecifier = this.pathToSpecifierImporters.get(path);
+    if (!importersBySpecifier) {
+      importersBySpecifier = new Map();
+      this.pathToSpecifierImporters.set(path, importersBySpecifier);
+    }
+
+    let importers = importersBySpecifier.get(specifier);
+    if (!importers) {
+      importers = new Set();
+      importersBySpecifier.set(specifier, importers);
+    }
+    importers.add(importer);
   }
 
   private normalizeMaxEntries(maxEntries: number | undefined): number {
@@ -519,16 +541,22 @@ export class ModuleSystem {
     this.resolvedPathByContext.deleteByPath(path);
   }
 
+  private hasInitializingModuleRecord(): boolean {
+    for (const record of this.cacheByPath.values()) {
+      if (record.status === "initializing") {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
   private evictOldestModuleIfNeeded(): void {
-    if (this.cacheByPath.size <= this.maxEntries) {
+    if (this.cacheByPath.size <= this.maxEntries || this.hasInitializingModuleRecord()) {
       return;
     }
 
-    for (const [path, record] of this.cacheByPath) {
-      if (record.status === "initializing") {
-        continue;
-      }
-
+    for (const path of this.cacheByPath.keys()) {
       this.evictModulePath(path);
       if (this.cacheByPath.size <= this.maxEntries) {
         return;
@@ -537,25 +565,51 @@ export class ModuleSystem {
   }
 
   private unregisterPath(path: string): void {
-    for (const [specifier, paths] of this.specifierToPaths) {
+    const specifiers = this.pathToSpecifiers.get(path);
+    if (!specifiers) {
+      return;
+    }
+
+    for (const specifier of specifiers) {
+      const paths = this.specifierToPaths.get(specifier);
+      if (!paths) {
+        continue;
+      }
+
       paths.delete(path);
       if (paths.size === 0) {
         this.specifierToPaths.delete(specifier);
       }
     }
 
-    for (const [specifier, pathsByImporter] of this.specifierToPathsByImporter) {
-      for (const [importer, paths] of pathsByImporter) {
-        paths.delete(path);
-        if (paths.size === 0) {
-          pathsByImporter.delete(importer);
+    const importersBySpecifier = this.pathToSpecifierImporters.get(path);
+    if (importersBySpecifier) {
+      for (const [specifier, importers] of importersBySpecifier) {
+        const pathsByImporter = this.specifierToPathsByImporter.get(specifier);
+        if (!pathsByImporter) {
+          continue;
+        }
+
+        for (const importer of importers) {
+          const paths = pathsByImporter.get(importer);
+          if (!paths) {
+            continue;
+          }
+
+          paths.delete(path);
+          if (paths.size === 0) {
+            pathsByImporter.delete(importer);
+          }
+        }
+
+        if (pathsByImporter.size === 0) {
+          this.specifierToPathsByImporter.delete(specifier);
         }
       }
-
-      if (pathsByImporter.size === 0) {
-        this.specifierToPathsByImporter.delete(specifier);
-      }
     }
+
+    this.pathToSpecifiers.delete(path);
+    this.pathToSpecifierImporters.delete(path);
   }
 
   private getUnambiguousPath(paths?: ReadonlySet<string>): string | undefined {
@@ -828,6 +882,8 @@ export class ModuleSystem {
     this.cacheByPath.clear();
     this.specifierToPaths.clear();
     this.specifierToPathsByImporter.clear();
+    this.pathToSpecifiers.clear();
+    this.pathToSpecifierImporters.clear();
     this.resolvedPathByContext.clear();
     this.evaluationStack = [];
   }

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -131,6 +131,7 @@ export interface SandboxModules {
   readonly externals?: Record<string, Record<string, unknown>>;
   readonly resolver?: ModuleResolver;
   readonly cache?: boolean;
+  readonly maxEntries?: number;
   readonly maxDepth?: number;
 }
 
@@ -442,6 +443,7 @@ const resolveModules = (modules?: SandboxModules): ModuleOptions | undefined => 
     enabled: true,
     resolver,
     cache: modules.cache,
+    maxEntries: modules.maxEntries,
     maxDepth: modules.maxDepth,
   };
 };

--- a/test/modules.test.ts
+++ b/test/modules.test.ts
@@ -4551,6 +4551,73 @@ describe("Module System", () => {
       expect(moduleSystem.getLoadedModules()).toEqual(["/two-second.js", "/three-third.js"]);
     });
 
+    test("should promote cached module records before bounded eviction", async () => {
+      const moduleSystem = new ModuleSystem({
+        enabled: true,
+        cache: true,
+        maxEntries: 2,
+        resolver: {
+          resolve(specifier) {
+            return {
+              type: "namespace",
+              exports: { value: specifier },
+              path: `/${specifier.slice(2)}.js`,
+            };
+          },
+          authorize() {
+            return true;
+          },
+        },
+      });
+
+      await moduleSystem.resolveModule("./a", "main.js");
+      await moduleSystem.resolveModule("./b", "main.js");
+      await moduleSystem.resolveModule("./a", "main.js");
+      await moduleSystem.resolveModule("./c", "main.js");
+
+      expect(moduleSystem.getCacheSize()).toBe(2);
+      expect(moduleSystem.isModuleCachedByPath("/a.js")).toBe(true);
+      expect(moduleSystem.isModuleCachedByPath("/b.js")).toBe(false);
+      expect(moduleSystem.isModuleCachedByPath("/c.js")).toBe(true);
+      expect(moduleSystem.getLoadedModules()).toEqual(["/a.js", "/c.js"]);
+    });
+
+    test("should defer bounded eviction until nested module initialization completes", async () => {
+      const files = new Map<string, string>([
+        ["a.js", 'import { value as b } from "b.js"; export const value = b + "a";'],
+        ["b.js", 'import { value as c } from "c.js"; export const value = c + "b";'],
+        ["c.js", 'export const value = "c";'],
+      ]);
+      const interpreter = new Interpreter({
+        modules: {
+          enabled: true,
+          cache: true,
+          maxEntries: 1,
+          resolver: {
+            resolve(specifier) {
+              const code = files.get(specifier);
+              if (code === undefined) {
+                return null;
+              }
+
+              return { type: "source", code, path: specifier };
+            },
+          },
+        },
+      });
+
+      const result = await interpreter.evaluateModuleAsync(
+        'import { value } from "a.js"; export const result = value;',
+        { path: "main.js" },
+      );
+
+      expect(result.result).toBe("cba");
+      expect(interpreter.getModuleCacheSize()).toBe(1);
+      expect(interpreter.isModuleCachedByPath("a.js")).toBe(true);
+      expect(interpreter.isModuleCachedByPath("b.js")).toBe(false);
+      expect(interpreter.isModuleCachedByPath("c.js")).toBe(false);
+    });
+
     test("should avoid JSON stringification when caching resolution contexts", async () => {
       let resolveCount = 0;
       const moduleSystem = new ModuleSystem({

--- a/test/modules.test.ts
+++ b/test/modules.test.ts
@@ -4510,6 +4510,47 @@ describe("Module System", () => {
       expect(internalModuleSystem.resolvedPathByContext.size).toBeLessThanOrEqual(1024);
     });
 
+    test("should bound module cache growth and keep indexes consistent", async () => {
+      const moduleSystem = new ModuleSystem({
+        enabled: true,
+        cache: true,
+        maxEntries: 2,
+        resolver: {
+          resolve(specifier, importer) {
+            return {
+              type: "namespace",
+              exports: { value: `${specifier}:${importer}` },
+              path: `/${specifier.slice(2)}-${importer}`,
+            };
+          },
+          authorize() {
+            return true;
+          },
+        },
+      });
+
+      await moduleSystem.resolveModule("./one", "first.js");
+      await moduleSystem.resolveModule("./two", "second.js");
+      await moduleSystem.resolveModule("./three", "third.js");
+
+      expect(moduleSystem.getCacheSize()).toBe(2);
+      expect(moduleSystem.isModuleCachedByPath("/one-first.js")).toBe(false);
+      expect(moduleSystem.isModuleCached("./one")).toBe(false);
+      expect(
+        moduleSystem.isModuleCached("./one", {
+          importer: "first.js",
+        }),
+      ).toBe(false);
+      expect(
+        moduleSystem.isModuleCached("./one", {
+          importer: "first.js",
+          importerChain: [],
+        }),
+      ).toBe(false);
+      expect(moduleSystem.getLoadedSpecifiers()).toEqual(["./two", "./three"]);
+      expect(moduleSystem.getLoadedModules()).toEqual(["/two-second.js", "/three-third.js"]);
+    });
+
     test("should avoid JSON stringification when caching resolution contexts", async () => {
       let resolveCount = 0;
       const moduleSystem = new ModuleSystem({


### PR DESCRIPTION
## Summary

Fixes #207 by adding an optional `maxEntries` setting to the module cache. When configured, the module system evicts the least recently used initialized module records once the cache exceeds that bound.

## Root Cause

`cacheByPath`, `specifierToPaths`, and `specifierToPathsByImporter` grew for the full lifetime of a sandbox. The resolved-path context cache was already bounded, but the main module record cache and its secondary indexes had no size limit.

## Changes

- Added `ModuleOptions.maxEntries` and forwarded `SandboxModules.maxEntries` from `createSandbox()`.
- Added LRU-style module record touching and eviction using `cacheByPath` insertion order.
- Centralized module path eviction so path, specifier, importer, and resolution-context indexes stay consistent.
- Documented bounded cache configuration in `docs/MODULES.md`.
- Added regression coverage for bounded growth and index cleanup.
- Added a changeset for the new option.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun lint` (passes with existing warnings)
- `bun test`
- `bun typecheck`

`bun lint` reports the existing warning set for `PROMISE_THEN` and several `await expect(...).rejects` assertions; it exits successfully with 0 errors.