### PR TITLE
[codex] Make shared memory an explicit opt-in

### DIFF
--- a/.changeset/shared-memory-opt-in.md
+++ b/.changeset/shared-memory-opt-in.md
@@ -1,0 +1,5 @@
+---
+"nookjs": minor
+---
+
+Split shared-memory primitives out of `BufferAPI` into a new explicit `SharedMemoryAPI` opt-in preset.

--- a/docs/PRESETS.md
+++ b/docs/PRESETS.md
@@ -148,20 +148,21 @@ ES2021+ presets add:
 
 Addon presets provide access to specific Web/Runtime APIs. They only add globals and don't modify feature control.
 
-| Preset           | Description             | Key Globals                                                             |
-| ---------------- | ----------------------- | ----------------------------------------------------------------------- |
-| `FetchAPI`       | HTTP requests           | `fetch`, `Request`, `Response`, `Headers`                               |
-| `ConsoleAPI`     | Logging                 | `console`                                                               |
-| `TimersAPI`      | Timers                  | `setTimeout`, `setInterval`                                             |
-| `TextCodecAPI`   | Text encoding/decoding  | `TextEncoder`, `TextDecoder`                                            |
-| `CryptoAPI`      | Cryptographic functions | `crypto`                                                                |
-| `RegExpAPI`      | Regular expressions     | `RegExp`                                                                |
-| `IntlAPI`        | Internationalization    | `Intl`                                                                  |
-| `BufferAPI`      | Binary data handling    | `ArrayBuffer`, `SharedArrayBuffer`, `Atomics`, `DataView`, typed arrays |
-| `StreamsAPI`     | Streaming data          | `ReadableStream`, `WritableStream`                                      |
-| `BlobAPI`        | Blob/File handling      | `Blob`, `File`                                                          |
-| `PerformanceAPI` | Performance measurement | `performance`                                                           |
-| `EventAPI`       | Custom events           | `Event`, `EventTarget`, `CustomEvent`                                   |
+| Preset            | Description             | Key Globals                               |
+| ----------------- | ----------------------- | ----------------------------------------- |
+| `FetchAPI`        | HTTP requests           | `fetch`, `Request`, `Response`, `Headers` |
+| `ConsoleAPI`      | Logging                 | `console`                                 |
+| `TimersAPI`       | Timers                  | `setTimeout`, `setInterval`               |
+| `TextCodecAPI`    | Text encoding/decoding  | `TextEncoder`, `TextDecoder`              |
+| `CryptoAPI`       | Cryptographic functions | `crypto`                                  |
+| `RegExpAPI`       | Regular expressions     | `RegExp`                                  |
+| `IntlAPI`         | Internationalization    | `Intl`                                    |
+| `BufferAPI`       | Binary data handling    | `ArrayBuffer`, `DataView`, typed arrays   |
+| `SharedMemoryAPI` | Shared-memory opt-in    | `SharedArrayBuffer`, `Atomics`            |
+| `StreamsAPI`      | Streaming data          | `ReadableStream`, `WritableStream`        |
+| `BlobAPI`         | Blob/File handling      | `Blob`, `File`                            |
+| `PerformanceAPI`  | Performance measurement | `performance`                             |
+| `EventAPI`        | Custom events           | `Event`, `EventTarget`, `CustomEvent`     |
 
 ### `FetchAPI`
 
@@ -282,8 +283,7 @@ await sandbox.run(`
 
 ### `BufferAPI`
 
-Provides binary data handling with `ArrayBuffer`, `SharedArrayBuffer`, `Atomics`, `DataView`,
-and typed arrays.
+Provides binary data handling with `ArrayBuffer`, `DataView`, and typed arrays.
 
 ```typescript
 const sandbox = createSandbox({ env: "es2022", apis: ["buffer"] });
@@ -296,11 +296,31 @@ await sandbox.run(`
 `);
 ```
 
-When the host runtime supports them, `SharedArrayBuffer` and `Atomics` are exposed together so
-shared memory remains usable inside the sandbox. If your embedder passes shared-memory-backed
-views across the sandbox boundary, treat them as mutable shared state rather than inert byte data.
+`BufferAPI` intentionally does not expose `SharedArrayBuffer` or `Atomics`. Use it when you need
+typed arrays and `ArrayBuffer` without adding shared-memory coordination primitives.
 
-**Includes:** `ArrayBuffer`, `SharedArrayBuffer`, `Atomics`, `DataView`, `Int8Array`, `Uint8Array`, `Uint8ClampedArray`, `Int16Array`, `Uint16Array`, `Int32Array`, `Uint32Array`, `Float32Array`, `Float64Array`, `BigInt64Array`, `BigUint64Array`
+**Includes:** `ArrayBuffer`, `DataView`, `Int8Array`, `Uint8Array`, `Uint8ClampedArray`, `Int16Array`, `Uint16Array`, `Int32Array`, `Uint32Array`, `Float32Array`, `Float64Array`, `BigInt64Array`, `BigUint64Array`
+
+### `SharedMemoryAPI`
+
+Provides explicit opt-in access to `SharedArrayBuffer` and `Atomics` when the host runtime supports
+them. Combine it with `BufferAPI` when sandbox code must construct typed array views over shared
+memory.
+
+```typescript
+const sandbox = createSandbox({ env: "es2022", apis: ["buffer", "shared-memory"] });
+
+await sandbox.run(`
+  const buffer = new SharedArrayBuffer(4);
+  const view = new Int32Array(buffer);
+  Atomics.store(view, 0, 42);
+`);
+```
+
+If your embedder passes shared-memory-backed views across the sandbox boundary, treat them as
+mutable shared state rather than inert byte data.
+
+**Includes:** `SharedArrayBuffer`, `Atomics`
 
 ### `StreamsAPI`
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -204,10 +204,12 @@ This prevents host objects from leaking sensitive data through custom `valueOf` 
 
 TypedArrays (e.g., `Uint8Array`, `Int32Array`) and `ArrayBuffer` instances have special security handling to balance usability with sandbox protection.
 
-If you also expose `BufferAPI`, the sandbox can receive `SharedArrayBuffer` and `Atomics` when the
-host runtime supports them. That is useful for shared-memory coordination, but it also means
-shared-memory-backed views can be mutated and synchronized across the sandbox boundary if your
-embedder shares those objects with host code or other sandboxes.
+`BufferAPI` exposes `ArrayBuffer`, `DataView`, and typed array constructors without exposing
+shared-memory primitives. If you also expose `SharedMemoryAPI`, the sandbox can receive
+`SharedArrayBuffer` and `Atomics` when the host runtime supports them. That is useful for
+shared-memory coordination, but it also means shared-memory-backed views can be mutated and
+synchronized across the sandbox boundary if your embedder shares those objects with host code or
+other sandboxes.
 
 #### Element Mutation is Allowed
 
@@ -281,8 +283,8 @@ await sandbox.run(`
 ### SharedArrayBuffer and Atomics Increase Coordination Power
 
 `SharedArrayBuffer` becomes materially more powerful once `Atomics` is available alongside it.
-With `BufferAPI`, sandbox code can coordinate through shared memory instead of only reading or
-writing buffer contents.
+With `SharedMemoryAPI`, sandbox code can coordinate through shared memory instead of only reading
+or writing buffer contents.
 
 Security tradeoff:
 
@@ -290,8 +292,9 @@ Security tradeoff:
   and synchronize mutations to the same underlying memory.
 - This does not create a sandbox escape by itself, but it does create a higher-bandwidth
   coordination channel than plain `ArrayBuffer`.
-- Only expose `BufferAPI` when your embedding model is comfortable with shared mutable memory, or
-  avoid passing shared-memory-backed views across trust boundaries.
+- Prefer `BufferAPI` when you only need typed arrays and `ArrayBuffer`.
+- Only expose `SharedMemoryAPI` when your embedding model is comfortable with shared mutable
+  memory, or avoid passing shared-memory-backed views across trust boundaries.
 
 **If you need stronger isolation:**
 

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -209,7 +209,7 @@ export const ES2016: InterpreterOptions = attachEcmaPresetVersion(
  * - async/await
  * - Object.values() / Object.entries() (via globals)
  * - String padding methods (on prototype)
- * - Shared memory and atomics (available via BufferAPI addon)
+ * - Shared memory and atomics (available via SharedMemoryAPI addon)
  */
 export const ES2017: InterpreterOptions = attachEcmaPresetVersion(
   {

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -733,8 +733,9 @@ export const IntlAPI: InterpreterOptions = {
 /**
  * Buffer API addon preset.
  *
- * Provides access to binary data handling with ArrayBuffer, SharedArrayBuffer, Atomics,
- * DataView, and typed arrays.
+ * Provides access to binary data handling with ArrayBuffer, DataView, and typed arrays.
+ * SharedArrayBuffer and Atomics are intentionally excluded; use SharedMemoryAPI when
+ * shared-memory coordination is explicitly required.
  *
  * @example
  * ```typescript
@@ -750,8 +751,6 @@ export const IntlAPI: InterpreterOptions = {
 export const BufferAPI: InterpreterOptions = {
   globals: {
     ArrayBuffer,
-    Atomics: typeof Atomics !== "undefined" ? Atomics : undefined,
-    SharedArrayBuffer: typeof SharedArrayBuffer !== "undefined" ? SharedArrayBuffer : undefined,
     DataView,
     // Typed arrays
     Int8Array,
@@ -765,6 +764,29 @@ export const BufferAPI: InterpreterOptions = {
     Float64Array,
     BigInt64Array,
     BigUint64Array,
+  },
+};
+
+/**
+ * Shared memory API addon preset.
+ *
+ * Provides explicit opt-in access to SharedArrayBuffer and Atomics when the host runtime
+ * supports them. Combine with BufferAPI to construct typed array views over shared memory.
+ *
+ * @example
+ * ```typescript
+ * const interpreter = new Interpreter(preset(ES2022, BufferAPI, SharedMemoryAPI));
+ * interpreter.evaluate(`
+ *   const buffer = new SharedArrayBuffer(4);
+ *   const view = new Int32Array(buffer);
+ *   Atomics.store(view, 0, 42);
+ * `);
+ * ```
+ */
+export const SharedMemoryAPI: InterpreterOptions = {
+  globals: {
+    Atomics: typeof Atomics !== "undefined" ? Atomics : undefined,
+    SharedArrayBuffer: typeof SharedArrayBuffer !== "undefined" ? SharedArrayBuffer : undefined,
   },
 };
 

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -38,6 +38,7 @@ import {
   NodeJS,
   PerformanceAPI,
   RegExpAPI,
+  SharedMemoryAPI,
   StreamsAPI,
   TextCodecAPI,
   TimersAPI,
@@ -88,6 +89,9 @@ export type SandboxApi =
   | "regex"
   | "intl"
   | "buffer"
+  | "sharedmemory"
+  | "shared-memory"
+  | "shared_memory"
   | "streams"
   | "blob"
   | "performance"
@@ -257,6 +261,9 @@ const API_PRESET_MAP: Record<string, InterpreterOptions> = {
   regex: RegExpAPI,
   intl: IntlAPI,
   buffer: BufferAPI,
+  sharedmemory: SharedMemoryAPI,
+  "shared-memory": SharedMemoryAPI,
+  shared_memory: SharedMemoryAPI,
   streams: StreamsAPI,
   blob: BlobAPI,
   performance: PerformanceAPI,

--- a/test/environment-presets.test.ts
+++ b/test/environment-presets.test.ts
@@ -183,6 +183,13 @@ describe("Presets", () => {
           expect(interpreter.evaluate("typeof DataView")).toBe("function");
         });
 
+        it("should not include shared-memory APIs by default", () => {
+          const interpreter = new Interpreter(NodeJS);
+
+          expect(interpreter.evaluate("typeof SharedArrayBuffer")).toBe("undefined");
+          expect(interpreter.evaluate("typeof Atomics")).toBe("undefined");
+        });
+
         it("should include performance API", () => {
           const interpreter = new Interpreter(NodeJS);
 

--- a/test/presets.test.ts
+++ b/test/presets.test.ts
@@ -20,6 +20,7 @@ import {
   RegExpAPI,
   IntlAPI,
   BufferAPI,
+  SharedMemoryAPI,
   StreamsAPI,
   BlobAPI,
   PerformanceAPI,
@@ -331,13 +332,9 @@ describe("Presets", () => {
           expect(BufferAPI.globals?.Float64Array).toBe(Float64Array);
         });
 
-        it("should provide Atomics when the host runtime supports shared memory", () => {
-          if (typeof Atomics === "undefined") {
-            expect(BufferAPI.globals?.Atomics).toBeUndefined();
-            return;
-          }
-
-          expect(BufferAPI.globals?.Atomics).toBe(Atomics);
+        it("should not provide shared-memory globals", () => {
+          expect(BufferAPI.globals?.Atomics).toBeUndefined();
+          expect(BufferAPI.globals?.SharedArrayBuffer).toBeUndefined();
         });
 
         it("should work with interpreter - ArrayBuffer", async () => {
@@ -360,12 +357,35 @@ describe("Presets", () => {
           expect(result).toBe(5);
         });
 
+        it("should keep shared-memory globals unavailable in the interpreter", async () => {
+          const interpreter = new Interpreter(preset(ES2022, BufferAPI));
+
+          const result = await interpreter.evaluateAsync(`
+            [typeof SharedArrayBuffer, typeof Atomics]
+          `);
+
+          expect(result).toEqual(["undefined", "undefined"]);
+        });
+      });
+
+      describe("SharedMemoryAPI", () => {
+        it("should provide shared-memory globals when the host runtime supports them", () => {
+          if (typeof Atomics === "undefined" || typeof SharedArrayBuffer === "undefined") {
+            expect(SharedMemoryAPI.globals?.Atomics).toBeUndefined();
+            expect(SharedMemoryAPI.globals?.SharedArrayBuffer).toBeUndefined();
+            return;
+          }
+
+          expect(SharedMemoryAPI.globals?.Atomics).toBe(Atomics);
+          expect(SharedMemoryAPI.globals?.SharedArrayBuffer).toBe(SharedArrayBuffer);
+        });
+
         it("should support Atomics operations on SharedArrayBuffer-backed views", async () => {
           if (typeof Atomics === "undefined" || typeof SharedArrayBuffer === "undefined") {
             return;
           }
 
-          const interpreter = new Interpreter(preset(ES2022, BufferAPI));
+          const interpreter = new Interpreter(preset(ES2022, BufferAPI, SharedMemoryAPI));
 
           const result = await interpreter.evaluateAsync(`
             const buffer = new SharedArrayBuffer(4);

--- a/test/sandbox-api.test.ts
+++ b/test/sandbox-api.test.ts
@@ -359,6 +359,23 @@ describe("Simplified API", () => {
     );
   });
 
+  it("should require the shared-memory API preset for SharedArrayBuffer and Atomics", async () => {
+    const bufferOnly = createSandbox({ env: "es2022", apis: ["buffer"] });
+    expect(await bufferOnly.run<string[]>("[typeof SharedArrayBuffer, typeof Atomics]")).toEqual([
+      "undefined",
+      "undefined",
+    ]);
+
+    if (typeof SharedArrayBuffer === "undefined" || typeof Atomics === "undefined") {
+      return;
+    }
+
+    const withSharedMemory = createSandbox({ env: "es2022", apis: ["buffer", "shared-memory"] });
+    expect(
+      await withSharedMemory.run<string[]>("[typeof SharedArrayBuffer, typeof Atomics]"),
+    ).toEqual(["function", "object"]);
+  });
+
   it("should allow enabling additional features", async () => {
     const sandbox = createSandbox({
       env: "es5",


### PR DESCRIPTION
## Summary

Closes #208.

This changes the binary-data preset so `BufferAPI` exposes `ArrayBuffer`, `DataView`, and typed array constructors without also exposing shared-memory coordination primitives. `SharedArrayBuffer` and `Atomics` are now available through a new explicit `SharedMemoryAPI` addon preset.

The simplified sandbox API also accepts `shared-memory`, `sharedmemory`, and `shared_memory` API names so embedders can opt into shared memory while keeping `buffer` as the safer default.

## Root Cause

`BufferAPI` bundled typed arrays and `ArrayBuffer` with `SharedArrayBuffer` and `Atomics`. That made a broad binary-data preset expose cross-sandbox coordination primitives by default, even when embedders only needed ordinary typed array support.

## Impact

Embedders can now enable binary data handling without shared mutable memory. Existing callers that intentionally need shared-memory-backed views should combine `BufferAPI` with `SharedMemoryAPI`, or use `apis: ["buffer", "shared-memory"]` through `createSandbox()`.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun lint` (passes with existing warnings)
- `bun test test/presets.test.ts test/sandbox-api.test.ts test/environment-presets.test.ts`
- `bun test`
- `bun typecheck`

## Notes

Added a changeset for the public preset/API surface change.