### PR TITLE
[codex] Add native unwrap clone strategy

### DIFF
--- a/.changeset/native-unwrap-clone-strategy.md
+++ b/.changeset/native-unwrap-clone-strategy.md
@@ -1,0 +1,5 @@
+---
+"nookjs": minor
+---
+
+Add an opt-in `security.nativeUnwrapStrategy: "clone"` mode that passes cloned or snapshotted allowlisted branded host objects to native host functions.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -34,6 +34,9 @@ const sandbox = createSandbox({
 
     // Optional extra branded types to unwrap for host API compatibility (default: none)
     nativeUnwrapAllowlist: ["DataView", "Headers"],
+
+    // Pass snapshots for allowlisted branded types instead of raw host instances (default: "raw")
+    nativeUnwrapStrategy: "clone",
   },
 });
 ```
@@ -132,6 +135,42 @@ Security tradeoff:
 - If you need `File` unwrapping, include `"File"` explicitly.
 - Container entries like `FormData` and `Request` may also require entry/body types like `Blob` or `File`; native APIs often expect real instances, not proxies.
 - Enable only the minimum set of types needed for your compatibility requirements.
+
+### `nativeUnwrapStrategy` (default: `"raw"`)
+
+`nativeUnwrapStrategy` controls what host functions receive for entries enabled by `nativeUnwrapAllowlist`.
+
+- `"raw"` passes the original host instance through. This preserves the previous behavior and has the highest compatibility, but mutable types like `DataView`, `Headers`, `URL`, `URLSearchParams`, and `FormData` can be mutated by the receiving host API.
+- `"clone"` passes a cloned or snapshotted branded instance where supported. Native brand checks still see the expected type, but mutations affect the clone instead of the original host object.
+
+Example:
+
+```typescript
+const sandbox = createSandbox({
+  env: "es2024",
+  globals: { headers, sendHeaders },
+  security: {
+    nativeUnwrapAllowlist: ["Headers"],
+    nativeUnwrapStrategy: "clone",
+  },
+});
+```
+
+Clone behavior by type:
+
+| Entry             | Clone strategy                                    | Mutability notes                                                      |
+| ----------------- | ------------------------------------------------- | --------------------------------------------------------------------- |
+| `DataView`        | Copies the viewed bytes into a new `ArrayBuffer`  | Writes through the clone do not affect the original buffer segment.   |
+| `Headers`         | Constructs `new Headers(original)`                | Header mutations are isolated to the snapshot.                        |
+| `URLSearchParams` | Constructs `new URLSearchParams(original)`        | Parameter mutations are isolated to the snapshot.                     |
+| `URL`             | Constructs `new URL(original.href)`               | URL property mutations are isolated to the snapshot.                  |
+| `FormData`        | Appends current entries into a new `FormData`     | Entry list changes are isolated; object/blob entry values are reused. |
+| `Request`         | Uses `request.clone()`                            | Body cloning follows the host runtime's `Request.clone()` semantics.  |
+| `Response`        | Uses `response.clone()`                           | Body cloning follows the host runtime's `Response.clone()` semantics. |
+| `Blob`            | Constructs `new Blob([original])`                 | Blob contents are immutable.                                          |
+| `File`            | Constructs `new File([original], name, metadata)` | File contents are immutable; name/type/lastModified are preserved.    |
+
+Use `"clone"` when you need brand-check compatibility but do not want host-call mutation to share state with the original object. Use `"raw"` when the native API requires identity preservation, live mutations, or host-specific internals that cannot be cloned safely.
 
 ## What is Blocked
 

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -22,7 +22,7 @@ import type {
   ModuleRecord,
   StarExportOrigin,
 } from "./modules";
-import type { NativeUnwrapAllowlistEntry } from "./readonly-proxy";
+import type { NativeUnwrapAllowlistEntry, NativeUnwrapStrategy } from "./readonly-proxy";
 
 import { parseModule, parseScript } from "./ast";
 import { isDangerousProperty, isDangerousSymbol, isForbiddenGlobalName } from "./constants";
@@ -2367,6 +2367,12 @@ export type SecurityOptions = {
    * Default: none (conservative mode).
    */
   nativeUnwrapAllowlist?: readonly NativeUnwrapAllowlistEntry[];
+
+  /**
+   * How allowlisted branded host object types are passed to native host
+   * functions. Defaults to "raw" for backwards compatibility.
+   */
+  nativeUnwrapStrategy?: NativeUnwrapStrategy;
 };
 
 export type NumericSemantics = "safe" | "strict-js";
@@ -2703,6 +2709,7 @@ export class Interpreter {
       sanitizeErrors: options?.security?.sanitizeErrors ?? true,
       hideHostErrorMessages: options?.security?.hideHostErrorMessages ?? true,
       nativeUnwrapAllowlist: options?.security?.nativeUnwrapAllowlist,
+      nativeUnwrapStrategy: options?.security?.nativeUnwrapStrategy,
     };
 
     // Initialize module system if provided

--- a/src/readonly-proxy.ts
+++ b/src/readonly-proxy.ts
@@ -45,6 +45,7 @@ const NATIVE_UNWRAP_ALLOWLIST_ENTRIES = [
 ] as const;
 
 export type NativeUnwrapAllowlistEntry = (typeof NATIVE_UNWRAP_ALLOWLIST_ENTRIES)[number];
+export type NativeUnwrapStrategy = "raw" | "clone";
 
 /**
  * Check if a value is a TypedArray instance.
@@ -112,6 +113,55 @@ function shouldUnwrapAllowlistedTarget(
   }
 
   return false;
+}
+
+function cloneAllowlistedTarget(target: unknown): unknown {
+  if (target instanceof DataView) {
+    const buffer = target.buffer.slice(target.byteOffset, target.byteOffset + target.byteLength);
+    return new DataView(buffer);
+  }
+
+  if (isInstanceOfGlobalConstructor(target, "Headers")) {
+    return new (globalThis as any).Headers(target);
+  }
+
+  if (isInstanceOfGlobalConstructor(target, "URLSearchParams")) {
+    return new (globalThis as any).URLSearchParams(target);
+  }
+
+  if (isInstanceOfGlobalConstructor(target, "URL")) {
+    return new URL((target as URL).href);
+  }
+
+  if (isInstanceOfGlobalConstructor(target, "FormData")) {
+    const cloned = new (globalThis as any).FormData();
+    for (const [name, value] of target as any) {
+      cloned.append(name, value);
+    }
+    return cloned;
+  }
+
+  if (
+    isInstanceOfGlobalConstructor(target, "Request") ||
+    isInstanceOfGlobalConstructor(target, "Response")
+  ) {
+    return (target as any).clone();
+  }
+
+  if (isInstanceOfGlobalConstructor(target, "File")) {
+    const file = target as any;
+    return new (globalThis as any).File([file], file.name, {
+      lastModified: file.lastModified,
+      type: file.type,
+    });
+  }
+
+  if (isInstanceOfGlobalConstructor(target, "Blob")) {
+    const blob = target as Blob;
+    return new Blob([blob], { type: blob.type });
+  }
+
+  return target;
 }
 
 function shouldUseShadowTarget(value: unknown): value is object {
@@ -187,6 +237,9 @@ export function unwrapForNative(value: unknown, securityOptions?: SecurityOption
   // Optionally unwrap additional branded host objects for compatibility.
   // Default remains conservative: no extra object types are unwrapped.
   if (shouldUnwrapAllowlistedTarget(target, effectiveSecurityOptions.nativeUnwrapAllowlist)) {
+    if (effectiveSecurityOptions.nativeUnwrapStrategy === "clone") {
+      return cloneAllowlistedTarget(target);
+    }
     return target;
   }
 
@@ -250,6 +303,17 @@ export interface SecurityOptions {
    * Only allow types you consider safe for your embedding environment.
    */
   nativeUnwrapAllowlist?: readonly NativeUnwrapAllowlistEntry[];
+
+  /**
+   * How allowlisted branded host objects are passed to native host functions.
+   *
+   * - "raw" passes the original host instance through for maximum compatibility.
+   * - "clone" passes a cloned/snapshotted instance where supported so host-call
+   *   mutation does not modify the original host object.
+   *
+   * Default: "raw" for backwards compatibility.
+   */
+  nativeUnwrapStrategy?: NativeUnwrapStrategy;
 }
 
 // Global security options - can be set by the Interpreter

--- a/src/readonly-proxy.ts
+++ b/src/readonly-proxy.ts
@@ -161,7 +161,9 @@ function cloneAllowlistedTarget(target: unknown): unknown {
     return new Blob([blob], { type: blob.type });
   }
 
-  return target;
+  throw new InterpreterError(
+    "nativeUnwrapStrategy 'clone' reached an allowlisted host object without a clone handler",
+  );
 }
 
 function shouldUseShadowTarget(value: unknown): value is object {

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -2732,6 +2732,60 @@ describe("Security", () => {
         expect(params.get("a")).toBe("1");
       });
 
+      it("should snapshot URL when native unwrap clone strategy is enabled", () => {
+        if (typeof URL !== "function") {
+          return;
+        }
+
+        const url = new URL("https://example.com/original?a=1");
+        const hostMutateUrl = (input: URL): string => {
+          input.pathname = "/changed";
+          input.searchParams.set("a", "2");
+          return input.href;
+        };
+
+        const interpreter = new Interpreter({
+          globals: { url, hostMutateUrl },
+          security: {
+            hideHostErrorMessages: false,
+            nativeUnwrapAllowlist: ["URL"],
+            nativeUnwrapStrategy: "clone",
+          },
+        });
+
+        const result = interpreter.evaluate("hostMutateUrl(url)");
+        expect(result).toBe("https://example.com/changed?a=2");
+        expect(url.href).toBe("https://example.com/original?a=1");
+      });
+
+      it("should snapshot FormData entries when native unwrap clone strategy is enabled", () => {
+        if (typeof FormData !== "function") {
+          return;
+        }
+
+        const formData = new FormData();
+        formData.append("name", "original");
+        const hostMutateFormData = (input: FormData): string | null => {
+          input.set("name", "changed");
+          input.append("extra", "value");
+          return input.get("name") as string | null;
+        };
+
+        const interpreter = new Interpreter({
+          globals: { formData, hostMutateFormData },
+          security: {
+            hideHostErrorMessages: false,
+            nativeUnwrapAllowlist: ["FormData"],
+            nativeUnwrapStrategy: "clone",
+          },
+        });
+
+        const result = interpreter.evaluate("hostMutateFormData(formData)");
+        expect(result).toBe("changed");
+        expect(formData.get("name")).toBe("original");
+        expect(formData.has("extra")).toBe(false);
+      });
+
       it("should allow Blob unwrapping when explicitly allowlisted", () => {
         if (typeof Blob !== "function") {
           return;

--- a/test/security.test.ts
+++ b/test/security.test.ts
@@ -2636,6 +2636,30 @@ describe("Security", () => {
         expect(result).toBe(65);
       });
 
+      it("should snapshot DataView when native unwrap clone strategy is enabled", () => {
+        const buffer = new ArrayBuffer(1);
+        const view = new DataView(buffer);
+        view.setUint8(0, 65);
+
+        const hostMutateByte = (input: DataView): number => {
+          input.setUint8(0, 90);
+          return input.getUint8(0);
+        };
+
+        const interpreter = new Interpreter({
+          globals: { view, hostMutateByte },
+          security: {
+            hideHostErrorMessages: false,
+            nativeUnwrapAllowlist: ["DataView"],
+            nativeUnwrapStrategy: "clone",
+          },
+        });
+
+        const result = interpreter.evaluate("hostMutateByte(view)");
+        expect(result).toBe(90);
+        expect(view.getUint8(0)).toBe(65);
+      });
+
       it("should allow Headers unwrapping when explicitly allowlisted", () => {
         if (typeof Headers !== "function") {
           return;
@@ -2656,6 +2680,56 @@ describe("Security", () => {
 
         const result = interpreter.evaluate("hostReadHeader(headers)");
         expect(result).toBe("ok");
+      });
+
+      it("should snapshot Headers when native unwrap clone strategy is enabled", () => {
+        if (typeof Headers !== "function") {
+          return;
+        }
+
+        const headers = new Headers([["x-test", "ok"]]);
+        const hostMutateHeader = (input: Headers): string | null => {
+          input.set("x-test", "changed");
+          return input.get("x-test");
+        };
+
+        const interpreter = new Interpreter({
+          globals: { headers, hostMutateHeader },
+          security: {
+            hideHostErrorMessages: false,
+            nativeUnwrapAllowlist: ["Headers"],
+            nativeUnwrapStrategy: "clone",
+          },
+        });
+
+        const result = interpreter.evaluate("hostMutateHeader(headers)");
+        expect(result).toBe("changed");
+        expect(headers.get("x-test")).toBe("ok");
+      });
+
+      it("should snapshot URLSearchParams when native unwrap clone strategy is enabled", () => {
+        if (typeof URLSearchParams !== "function") {
+          return;
+        }
+
+        const params = new URLSearchParams("a=1");
+        const hostMutateParams = (input: URLSearchParams): string | null => {
+          input.set("a", "2");
+          return input.get("a");
+        };
+
+        const interpreter = new Interpreter({
+          globals: { params, hostMutateParams },
+          security: {
+            hideHostErrorMessages: false,
+            nativeUnwrapAllowlist: ["URLSearchParams"],
+            nativeUnwrapStrategy: "clone",
+          },
+        });
+
+        const result = interpreter.evaluate("hostMutateParams(params)");
+        expect(result).toBe("2");
+        expect(params.get("a")).toBe("1");
       });
 
       it("should allow Blob unwrapping when explicitly allowlisted", () => {


### PR DESCRIPTION
## Summary

Fixes #209.

This adds an opt-in `security.nativeUnwrapStrategy: "clone"` mode for `nativeUnwrapAllowlist` entries. The existing default remains raw passthrough for backwards compatibility, but embedders can now request cloned or snapshotted branded host objects when native host APIs need brand-compatible values without receiving the original mutable host instance.

## Details

- Adds the `NativeUnwrapStrategy` type and `nativeUnwrapStrategy` security option.
- Implements clone/snapshot handling for allowlisted branded types including `DataView`, `Headers`, `URLSearchParams`, `URL`, `FormData`, `Request`, `Response`, `Blob`, and `File`.
- Documents raw versus clone tradeoffs and per-type clone behavior in `docs/SECURITY.md`.
- Adds regression coverage proving native brand-compatible calls still work while mutations to cloned `DataView`, `Headers`, and `URLSearchParams` do not affect the original host objects.
- Includes a changeset for the new opt-in API.

## Validation

- `bun test test/security.test.ts`
- `bun fmt`
- `bun lint:fix` (completed with existing warnings, no errors)
- `bun test`
- `bun typecheck`