### PR TITLE
[codex] add isolated sync hard-stop execution

### DIFF
--- a/.changeset/isolated-sync-hard-stop.md
+++ b/.changeset/isolated-sync-hard-stop.md
@@ -1,0 +1,5 @@
+---
+"nookjs": minor
+---
+
+Add `runSyncIsolated()` as a process-backed synchronous execution helper with a hard wall-clock timeout for hostile untrusted code.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -472,6 +472,33 @@ await sandbox.run(code, {
 });
 ```
 
+For synchronous untrusted code that needs a hard wall-clock stop, use the isolated sync helper:
+
+```typescript
+import { runSyncIsolated } from "nookjs";
+
+runSyncIsolated("while (true) {}", {
+  timeoutMs: 100,
+  sandbox: {
+    env: "es2022",
+    limits: { perRun: { callDepth: 100, memoryBytes: 10 * 1024 * 1024 } },
+  },
+});
+```
+
+`runSyncIsolated()` launches a separate Bun process for the evaluation and terminates it when
+`timeoutMs` expires. This is the hard-stop mode for hostile synchronous code; unlike cooperative
+loop, call-depth, memory, `AbortSignal`, or async timeout checks, it does not require the interpreted
+program to reach a check point on the caller's thread.
+
+Tradeoffs:
+
+- Use it for one-off sync executions; it does not share state with a reusable sandbox.
+- `options` and returned values must be JSON-serializable.
+- Host functions, validators, custom module resolvers, and `AbortSignal` cannot cross the process boundary.
+- Startup and serialization are slower than in-process `runSync()`.
+- Platform support follows the current Bun executable because the child process is launched with it.
+
 ### Execution Limits and AbortSignal
 
 You can also use `AbortSignal` for immediate cancellation of async execution:

--- a/docs/SIMPLIFIED_API.md
+++ b/docs/SIMPLIFIED_API.md
@@ -6,10 +6,13 @@ NookJS includes a simplified API for common use cases. Use `run()` for one-off e
 ## One-off execution
 
 ```typescript
-import { run } from "nookjs";
+import { run, runSyncIsolated } from "nookjs";
 
 const value = await run("2 + 3 * 4");
 console.log(value); // 14
+
+const syncValue = runSyncIsolated("2 + 3 * 4", { timeoutMs: 1000 });
+console.log(syncValue); // 14
 ```
 
 ## Create a sandbox
@@ -126,6 +129,28 @@ const sandbox = createSandbox({
 
 await sandbox.run(untrustedCode, { timeoutMs: 1000 }); // per-call override
 ```
+
+`timeoutMs` remains async-only for reusable `sandbox.runSync()` because synchronous code cannot be
+preempted safely on the caller's thread. Use `runSyncIsolated()` when you need a synchronous API
+surface with a hard wall-clock stop:
+
+```typescript
+import { runSyncIsolated } from "nookjs";
+
+const value = runSyncIsolated("while (true) {}", {
+  timeoutMs: 100,
+  sandbox: { env: "es2022" },
+});
+```
+
+`runSyncIsolated()` runs the evaluation in a separate Bun process and terminates that process when
+the timeout expires. This is the hard-stop mode for hostile synchronous code. Tradeoffs:
+
+- It is one-off only; state is not shared with a reusable sandbox.
+- `options` and returned values must be JSON-serializable.
+- Host functions, validators, custom module resolvers, and `AbortSignal` cannot cross the process boundary.
+- Startup and serialization make it slower than in-process `runSync()`.
+- It requires a Bun-compatible runtime because the child process is launched with the current Bun executable.
 
 ### `policy`
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,8 +38,11 @@ export {
 export {
   createSandbox,
   run,
+  runSyncIsolated,
   parse,
   type FeatureToggles,
+  type IsolatedRunSyncOptions,
+  type IsolatedRunSyncOptionsFull,
   type ParseOnceOptions,
   type ResultMode,
   type RunLimits,

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -13,7 +13,14 @@ import type {
 import type { ModuleOptions, ModuleResolver } from "./modules";
 import type { ResourceStats } from "./resource-tracker";
 
-import { ExecutionAbortedError } from "./errors";
+import {
+  ExecutionAbortedError,
+  FeatureError,
+  InterpreterError,
+  ParseError,
+  RuntimeError,
+  SecurityError,
+} from "./errors";
 import { Interpreter } from "./interpreter";
 import {
   BlobAPI,
@@ -48,6 +55,7 @@ import {
   WinterCG,
   preset,
 } from "./presets";
+import { ResourceExhaustedError } from "./resource-tracker";
 
 export type SandboxEnv =
   | "minimal"
@@ -520,6 +528,9 @@ const assertJsonSerializable = (name: string, value: unknown): void => {
     if (type === "function" || type === "symbol" || type === "bigint") {
       throw new Error(`${name} must be JSON-serializable for isolated sync execution`);
     }
+    if (type === "number" && !Number.isFinite(current)) {
+      throw new Error(`${name} must be JSON-serializable for isolated sync execution`);
+    }
     if (!current || type !== "object") {
       return;
     }
@@ -791,10 +802,38 @@ interface IsolatedChildFailure {
     readonly name: string;
     readonly message: string;
     readonly stack?: string;
+    readonly properties?: Record<string, unknown>;
   };
 }
 
 type IsolatedChildResult = IsolatedChildSuccess | IsolatedChildFailure;
+
+const ISOLATED_ERROR_PROTOTYPES: Record<string, Error> = {
+  ExecutionAbortedError: ExecutionAbortedError.prototype,
+  FeatureError: FeatureError.prototype,
+  InterpreterError: InterpreterError.prototype,
+  ParseError: ParseError.prototype,
+  ResourceExhaustedError: ResourceExhaustedError.prototype,
+  RuntimeError: RuntimeError.prototype,
+  SecurityError: SecurityError.prototype,
+};
+
+const reconstructIsolatedError = (serialized: IsolatedChildFailure["error"]): Error => {
+  const error = new Error(serialized.message);
+  error.name = serialized.name;
+  error.stack = serialized.stack;
+
+  for (const [key, value] of Object.entries(serialized.properties ?? {})) {
+    (error as unknown as Record<string, unknown>)[key] = value;
+  }
+
+  const prototype = ISOLATED_ERROR_PROTOTYPES[serialized.name];
+  if (prototype) {
+    Object.setPrototypeOf(error, prototype);
+  }
+
+  return error;
+};
 
 export function runSyncIsolated<T = unknown>(
   code: string,
@@ -823,12 +862,16 @@ try {
   const value = sandbox.runSync(input.code, runOptions);
   process.stdout.write(JSON.stringify({ ok: true, value }));
 } catch (error) {
+  const properties = error && typeof error === "object" ? Object.fromEntries(
+    Object.entries(error).filter(([, value]) => typeof value !== "function")
+  ) : undefined;
   process.stdout.write(JSON.stringify({
     ok: false,
     error: {
       name: error && typeof error === "object" && "name" in error ? error.name : "Error",
       message: error instanceof Error ? error.message : String(error),
       stack: error instanceof Error ? error.stack : undefined,
+      properties,
     },
   }));
   process.exitCode = 1;
@@ -859,10 +902,7 @@ try {
     return payload.value as T | RunResult<T>;
   }
 
-  const error = new Error(payload.error.message);
-  error.name = payload.error.name;
-  error.stack = payload.error.stack;
-  throw error;
+  throw reconstructIsolatedError(payload.error);
 }
 
 export const parse = (code: string, options?: ParseOnceOptions): ESTree.Program => {

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -1,3 +1,5 @@
+import { spawnSync } from "node:child_process";
+
 import type { ESTree } from "./ast";
 import type {
   EvaluateOptions,
@@ -11,6 +13,7 @@ import type {
 import type { ModuleOptions, ModuleResolver } from "./modules";
 import type { ResourceStats } from "./resource-tracker";
 
+import { ExecutionAbortedError } from "./errors";
 import { Interpreter } from "./interpreter";
 import {
   BlobAPI,
@@ -194,6 +197,19 @@ export interface RunOnceOptions extends RunOptions {
 }
 
 export interface RunOnceOptionsFull extends RunOnceOptions {
+  readonly result: "full";
+}
+
+export interface IsolatedRunSyncOptions extends Omit<RunOnceOptions, "signal" | "timeoutMs"> {
+  /**
+   * Wall-clock timeout for the isolated process. When exceeded, the child
+   * process is terminated so hostile synchronous code cannot monopolize the
+   * caller's thread.
+   */
+  readonly timeoutMs: number;
+}
+
+export interface IsolatedRunSyncOptionsFull extends IsolatedRunSyncOptions {
   readonly result: "full";
 }
 
@@ -494,6 +510,37 @@ const validateTimeoutMs = (timeoutMs: number): void => {
   }
 };
 
+const assertJsonSerializable = (name: string, value: unknown): void => {
+  const seen = new WeakSet<object>();
+  const visit = (path: string, current: unknown): void => {
+    if (current === undefined) {
+      return;
+    }
+    const type = typeof current;
+    if (type === "function" || type === "symbol" || type === "bigint") {
+      throw new Error(`${name} must be JSON-serializable for isolated sync execution`);
+    }
+    if (!current || type !== "object") {
+      return;
+    }
+    if (seen.has(current)) {
+      throw new Error(`${name} must not contain circular references`);
+    }
+    seen.add(current);
+    if (Array.isArray(current)) {
+      for (let index = 0; index < current.length; index++) {
+        visit(`${path}[${index}]`, current[index]);
+      }
+      return;
+    }
+    for (const [key, nested] of Object.entries(current as Record<string, unknown>)) {
+      visit(`${path}.${key}`, nested);
+    }
+  };
+
+  visit(name, value);
+};
+
 const resolveRunSignal = (defaultTimeoutMs?: number, options?: RunOptions): ResolvedRunSignal => {
   const timeoutMs = options?.timeoutMs ?? defaultTimeoutMs;
   const externalSignal = options?.signal;
@@ -731,6 +778,91 @@ export async function run<T = unknown>(
 ): Promise<T | RunResult<T>> {
   const sandbox = createSandbox(options?.sandbox);
   return sandbox.run<T>(code, options);
+}
+
+interface IsolatedChildSuccess {
+  readonly ok: true;
+  readonly value: unknown;
+}
+
+interface IsolatedChildFailure {
+  readonly ok: false;
+  readonly error: {
+    readonly name: string;
+    readonly message: string;
+    readonly stack?: string;
+  };
+}
+
+type IsolatedChildResult = IsolatedChildSuccess | IsolatedChildFailure;
+
+export function runSyncIsolated<T = unknown>(
+  code: string,
+  options: IsolatedRunSyncOptionsFull,
+): RunResult<T>;
+export function runSyncIsolated<T = unknown>(code: string, options: IsolatedRunSyncOptions): T;
+export function runSyncIsolated<T = unknown>(
+  code: string,
+  options: IsolatedRunSyncOptions,
+): T | RunResult<T> {
+  validateTimeoutMs(options.timeoutMs);
+  assertJsonSerializable("options", options);
+
+  const childInput = JSON.stringify({
+    code,
+    options,
+    moduleUrl: import.meta.url,
+  });
+
+  const childScript = `
+const input = JSON.parse(await Bun.stdin.text());
+const { createSandbox } = await import(input.moduleUrl);
+try {
+  const sandbox = createSandbox(input.options.sandbox);
+  const { sandbox: _sandbox, timeoutMs: _timeoutMs, ...runOptions } = input.options;
+  const value = sandbox.runSync(input.code, runOptions);
+  process.stdout.write(JSON.stringify({ ok: true, value }));
+} catch (error) {
+  process.stdout.write(JSON.stringify({
+    ok: false,
+    error: {
+      name: error && typeof error === "object" && "name" in error ? error.name : "Error",
+      message: error instanceof Error ? error.message : String(error),
+      stack: error instanceof Error ? error.stack : undefined,
+    },
+  }));
+  process.exitCode = 1;
+}
+`;
+
+  const result = spawnSync(process.execPath, ["--eval", childScript], {
+    input: childInput,
+    encoding: "utf8",
+    timeout: options.timeoutMs,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+
+  if (result.error) {
+    if ((result.error as NodeJS.ErrnoException).code === "ETIMEDOUT") {
+      throw new ExecutionAbortedError();
+    }
+    throw result.error;
+  }
+
+  const output = result.stdout.trim();
+  if (!output) {
+    throw new Error(result.stderr.trim() || "Isolated sync execution failed");
+  }
+
+  const payload = JSON.parse(output) as IsolatedChildResult;
+  if (payload.ok) {
+    return payload.value as T | RunResult<T>;
+  }
+
+  const error = new Error(payload.error.message);
+  error.name = payload.error.name;
+  error.stack = payload.error.stack;
+  throw error;
 }
 
 export const parse = (code: string, options?: ParseOnceOptions): ESTree.Program => {

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -522,7 +522,7 @@ const assertJsonSerializable = (name: string, value: unknown): void => {
   const seen = new WeakSet<object>();
   const visit = (path: string, current: unknown): void => {
     if (current === undefined) {
-      return;
+      throw new Error(`${name} must be JSON-serializable for isolated sync execution`);
     }
     const type = typeof current;
     if (type === "function" || type === "symbol" || type === "bigint") {
@@ -856,16 +856,39 @@ export function runSyncIsolated<T = unknown>(
   const childScript = `
 const input = JSON.parse(await Bun.stdin.text());
 const { createSandbox } = await import(input.moduleUrl);
-try {
-  const sandbox = createSandbox(input.options.sandbox);
-  const { sandbox: _sandbox, timeoutMs: _timeoutMs, ...runOptions } = input.options;
-  const value = sandbox.runSync(input.code, runOptions);
-  process.stdout.write(JSON.stringify({ ok: true, value }));
-} catch (error) {
-  const properties = error && typeof error === "object" ? Object.fromEntries(
-    Object.entries(error).filter(([, value]) => typeof value !== "function")
-  ) : undefined;
-  process.stdout.write(JSON.stringify({
+const cloneSerializable = (value, seen = new WeakSet()) => {
+  if (value === undefined || typeof value === "function" || typeof value === "symbol") {
+    return undefined;
+  }
+  if (typeof value === "bigint") {
+    return String(value);
+  }
+  if (typeof value === "number" && !Number.isFinite(value)) {
+    return String(value);
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+  if (seen.has(value)) {
+    return "[Circular]";
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    return value.map((item) => cloneSerializable(item, seen));
+  }
+  const output = {};
+  for (const [key, nested] of Object.entries(value)) {
+    const cloned = cloneSerializable(nested, seen);
+    if (cloned !== undefined) {
+      output[key] = cloned;
+    }
+  }
+  seen.delete(value);
+  return output;
+};
+const writeFailure = (error) => {
+  const properties = error && typeof error === "object" ? cloneSerializable(error) : undefined;
+  const payload = {
     ok: false,
     error: {
       name: error && typeof error === "object" && "name" in error ? error.name : "Error",
@@ -873,7 +896,27 @@ try {
       stack: error instanceof Error ? error.stack : undefined,
       properties,
     },
-  }));
+  };
+  try {
+    process.stdout.write(JSON.stringify(payload));
+  } catch {
+    process.stdout.write(JSON.stringify({
+      ok: false,
+      error: {
+        name: payload.error.name,
+        message: payload.error.message,
+        stack: payload.error.stack,
+      },
+    }));
+  }
+};
+try {
+  const sandbox = createSandbox(input.options.sandbox);
+  const { sandbox: _sandbox, timeoutMs: _timeoutMs, ...runOptions } = input.options;
+  const value = sandbox.runSync(input.code, runOptions);
+  process.stdout.write(JSON.stringify({ ok: true, value }));
+} catch (error) {
+  writeFailure(error);
   process.exitCode = 1;
 }
 `;

--- a/test/sandbox-api.test.ts
+++ b/test/sandbox-api.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test";
 
-import { ResourceExhaustedError } from "../src";
+import { InterpreterError, ResourceExhaustedError } from "../src";
 import { createSandbox, parse, run, runSyncIsolated } from "../src/sandbox";
 
 describe("Simplified API", () => {
@@ -639,12 +639,49 @@ describe("Simplified API", () => {
     ).toThrow("Undefined variable");
   });
 
+  it("runSyncIsolated() should preserve known child error identity", () => {
+    expect(() =>
+      runSyncIsolated("missingValue + 1", {
+        timeoutMs: 1000,
+      }),
+    ).toThrow(InterpreterError);
+
+    expect(() =>
+      runSyncIsolated("1 + 1", {
+        timeoutMs: 1000,
+        sandbox: {
+          limits: { total: { evaluations: 0 } },
+        },
+      }),
+    ).toThrow(ResourceExhaustedError);
+  });
+
   it("runSyncIsolated() should require serializable options", () => {
     expect(() =>
       runSyncIsolated("1 + 1", {
         timeoutMs: 1000,
         sandbox: {
           globals: { fn: () => 1 },
+        },
+      }),
+    ).toThrow("options must be JSON-serializable for isolated sync execution");
+  });
+
+  it("runSyncIsolated() should reject non-finite numbers before JSON serialization", () => {
+    expect(() =>
+      runSyncIsolated("1 + 1", {
+        timeoutMs: 1000,
+        sandbox: {
+          limits: { perRun: { loops: Number.NaN } },
+        },
+      }),
+    ).toThrow("options must be JSON-serializable for isolated sync execution");
+
+    expect(() =>
+      runSyncIsolated("1 + 1", {
+        timeoutMs: 1000,
+        sandbox: {
+          limits: { perRun: { memoryBytes: Number.POSITIVE_INFINITY } },
         },
       }),
     ).toThrow("options must be JSON-serializable for isolated sync execution");

--- a/test/sandbox-api.test.ts
+++ b/test/sandbox-api.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "bun:test";
 
 import { ResourceExhaustedError } from "../src";
-import { createSandbox, parse, run } from "../src/sandbox";
+import { createSandbox, parse, run, runSyncIsolated } from "../src/sandbox";
 
 describe("Simplified API", () => {
   it("run() should evaluate code", async () => {
@@ -607,6 +607,47 @@ describe("Simplified API", () => {
     expect(() => sandbox.runSync("1 + 1", { timeoutMs: 10 })).toThrow(
       "timeoutMs is only supported for async execution",
     );
+  });
+
+  it("runSyncIsolated() should evaluate synchronous code with a timeout", () => {
+    const result = runSyncIsolated<number>("value * 2", {
+      timeoutMs: 1000,
+      sandbox: {
+        globals: { value: 21 },
+      },
+    });
+
+    expect(result).toBe(42);
+  });
+
+  it("runSyncIsolated() should hard-stop hostile synchronous code", () => {
+    expect(() =>
+      runSyncIsolated("while (true) {}", {
+        timeoutMs: 50,
+        sandbox: {
+          limits: { perRun: { loops: Number.MAX_SAFE_INTEGER } },
+        },
+      }),
+    ).toThrow("Execution aborted");
+  });
+
+  it("runSyncIsolated() should propagate child execution errors", () => {
+    expect(() =>
+      runSyncIsolated("missingValue + 1", {
+        timeoutMs: 1000,
+      }),
+    ).toThrow("Undefined variable");
+  });
+
+  it("runSyncIsolated() should require serializable options", () => {
+    expect(() =>
+      runSyncIsolated("1 + 1", {
+        timeoutMs: 1000,
+        sandbox: {
+          globals: { fn: () => 1 },
+        },
+      }),
+    ).toThrow("options must be JSON-serializable for isolated sync execution");
   });
 
   it("runSync() should reject AbortSignal", () => {

--- a/test/sandbox-api.test.ts
+++ b/test/sandbox-api.test.ts
@@ -667,6 +667,25 @@ describe("Simplified API", () => {
     ).toThrow("options must be JSON-serializable for isolated sync execution");
   });
 
+  it("runSyncIsolated() should reject undefined options before JSON serialization", () => {
+    expect(() =>
+      runSyncIsolated("x", {
+        timeoutMs: 1000,
+        sandbox: {
+          globals: { x: undefined },
+        },
+      }),
+    ).toThrow("options must be JSON-serializable for isolated sync execution");
+  });
+
+  it("runSyncIsolated() should propagate errors with non-serializable thrown values", () => {
+    expect(() =>
+      runSyncIsolated("throw { nested: { fn: function () {} } }", {
+        timeoutMs: 1000,
+      }),
+    ).toThrow(InterpreterError);
+  });
+
   it("runSyncIsolated() should reject non-finite numbers before JSON serialization", () => {
     expect(() =>
       runSyncIsolated("1 + 1", {


### PR DESCRIPTION
## Summary

Closes #210.

Adds `runSyncIsolated()` as an explicit hard-stop mode for synchronous untrusted code. The helper launches a separate Bun process for one-off sync evaluation and uses the process timeout to terminate hostile CPU-bound executions that would otherwise monopolize the caller's thread.

## Why

`timeoutMs` and `AbortSignal` remain async-only for in-process execution because synchronous evaluation cannot be preempted safely once CPU-bound user code is running. This PR adds a separate sync API surface with explicit isolation semantics instead of changing `runSync()` behavior or weakening the existing async timeout model.

## Changes

- Export `runSyncIsolated()` plus `IsolatedRunSyncOptions` types from the simplified API.
- Require `timeoutMs` for isolated sync execution and throw `ExecutionAbortedError` when the child process times out.
- Validate isolated options as JSON-serializable before spawning the child process.
- Document performance, determinism, platform, state-sharing, host function, validator, resolver, and serialization tradeoffs in `docs/SECURITY.md` and `docs/SIMPLIFIED_API.md`.
- Add regression coverage for successful isolated sync execution, forced termination, child error propagation, and non-serializable options.
- Add a changeset for the new API.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun lint` (passes with existing warnings only)
- `bun test`
- `bun typecheck`