### PR TITLE
[codex] Remove Node-specific runtime code from core package

### DIFF
--- a/.changeset/runtime-neutral-core.md
+++ b/.changeset/runtime-neutral-core.md
@@ -1,0 +1,5 @@
+---
+"nookjs": minor
+---
+
+Remove Node/Bun process-spawning code from the runtime-neutral core package so it can be bundled for browser and WinterCG environments.

--- a/.changeset/runtime-neutral-core.md
+++ b/.changeset/runtime-neutral-core.md
@@ -1,5 +1,5 @@
 ---
-"nookjs": minor
+"nookjs": major
 ---
 
 Remove Node/Bun process-spawning code from the runtime-neutral core package so it can be bundled for browser and WinterCG environments.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -472,32 +472,17 @@ await sandbox.run(code, {
 });
 ```
 
-For synchronous untrusted code that needs a hard wall-clock stop, use the isolated sync helper:
-
-```typescript
-import { runSyncIsolated } from "nookjs";
-
-runSyncIsolated("while (true) {}", {
-  timeoutMs: 100,
-  sandbox: {
-    env: "es2022",
-    limits: { perRun: { callDepth: 100, memoryBytes: 10 * 1024 * 1024 } },
-  },
-});
-```
-
-`runSyncIsolated()` launches a separate Bun process for the evaluation and terminates it when
-`timeoutMs` expires. This is the hard-stop mode for hostile synchronous code; unlike cooperative
-loop, call-depth, memory, `AbortSignal`, or async timeout checks, it does not require the interpreted
-program to reach a check point on the caller's thread.
+For synchronous untrusted code that needs a hard wall-clock stop, run NookJS inside an
+application-owned Worker or process and terminate that host isolate from outside it. The core
+package does not spawn processes because it must remain compatible with browser and WinterCG
+runtimes.
 
 Tradeoffs:
 
-- Use it for one-off sync executions; it does not share state with a reusable sandbox.
-- `options` and returned values must be JSON-serializable.
-- Host functions, validators, custom module resolvers, and `AbortSignal` cannot cross the process boundary.
+- Host-isolated sync execution is one-off by default unless your host isolate protocol preserves state.
+- Inputs and returned values usually need to be structured-cloneable or JSON-serializable.
+- Host functions, validators, custom module resolvers, and `AbortSignal` may require runtime-specific bridging.
 - Startup and serialization are slower than in-process `runSync()`.
-- Platform support follows the current Bun executable because the child process is launched with it.
 
 ### Execution Limits and AbortSignal
 

--- a/docs/SIMPLIFIED_API.md
+++ b/docs/SIMPLIFIED_API.md
@@ -6,13 +6,10 @@ NookJS includes a simplified API for common use cases. Use `run()` for one-off e
 ## One-off execution
 
 ```typescript
-import { run, runSyncIsolated } from "nookjs";
+import { run } from "nookjs";
 
 const value = await run("2 + 3 * 4");
 console.log(value); // 14
-
-const syncValue = runSyncIsolated("2 + 3 * 4", { timeoutMs: 1000 });
-console.log(syncValue); // 14
 ```
 
 ## Create a sandbox
@@ -131,26 +128,10 @@ await sandbox.run(untrustedCode, { timeoutMs: 1000 }); // per-call override
 ```
 
 `timeoutMs` remains async-only for reusable `sandbox.runSync()` because synchronous code cannot be
-preempted safely on the caller's thread. Use `runSyncIsolated()` when you need a synchronous API
-surface with a hard wall-clock stop:
-
-```typescript
-import { runSyncIsolated } from "nookjs";
-
-const value = runSyncIsolated("while (true) {}", {
-  timeoutMs: 100,
-  sandbox: { env: "es2022" },
-});
-```
-
-`runSyncIsolated()` runs the evaluation in a separate Bun process and terminates that process when
-the timeout expires. This is the hard-stop mode for hostile synchronous code. Tradeoffs:
-
-- It is one-off only; state is not shared with a reusable sandbox.
-- `options` and returned values must be JSON-serializable.
-- Host functions, validators, custom module resolvers, and `AbortSignal` cannot cross the process boundary.
-- Startup and serialization make it slower than in-process `runSync()`.
-- It requires a Bun-compatible runtime because the child process is launched with the current Bun executable.
+preempted safely on the caller's thread. If you need a hard wall-clock stop for synchronous
+untrusted code, execute `runSync()` inside an application-owned Worker or process and terminate that
+host isolate from outside it. The core package does not spawn processes so it can run in browser and
+WinterCG runtimes.
 
 ### `policy`
 

--- a/src/presets.ts
+++ b/src/presets.ts
@@ -297,7 +297,7 @@ export const ES2020: InterpreterOptions = attachEcmaPresetVersion(
       ...ES2019.globals,
       // ES2020 additions
       BigInt,
-      globalThis: typeof globalThis !== "undefined" ? globalThis : global,
+      globalThis,
     },
   },
   2020,
@@ -1085,7 +1085,7 @@ export const Minimal: InterpreterOptions = attachEcmaPresetVersion(
       WeakSet,
       BigInt,
       // ES2020+
-      globalThis: typeof globalThis !== "undefined" ? globalThis : global,
+      globalThis,
     },
   },
   2024,

--- a/src/sandbox.ts
+++ b/src/sandbox.ts
@@ -1,5 +1,3 @@
-import { spawnSync } from "node:child_process";
-
 import type { ESTree } from "./ast";
 import type {
   EvaluateOptions,
@@ -13,14 +11,6 @@ import type {
 import type { ModuleOptions, ModuleResolver } from "./modules";
 import type { ResourceStats } from "./resource-tracker";
 
-import {
-  ExecutionAbortedError,
-  FeatureError,
-  InterpreterError,
-  ParseError,
-  RuntimeError,
-  SecurityError,
-} from "./errors";
 import { Interpreter } from "./interpreter";
 import {
   BlobAPI,
@@ -55,7 +45,6 @@ import {
   WinterCG,
   preset,
 } from "./presets";
-import { ResourceExhaustedError } from "./resource-tracker";
 
 export type SandboxEnv =
   | "minimal"
@@ -210,9 +199,10 @@ export interface RunOnceOptionsFull extends RunOnceOptions {
 
 export interface IsolatedRunSyncOptions extends Omit<RunOnceOptions, "signal" | "timeoutMs"> {
   /**
-   * Wall-clock timeout for the isolated process. When exceeded, the child
-   * process is terminated so hostile synchronous code cannot monopolize the
-   * caller's thread.
+   * Wall-clock timeout for host-provided isolated execution.
+   *
+   * The core package does not spawn child processes because it must remain
+   * compatible with WinterCG and browser runtimes.
    */
   readonly timeoutMs: number;
 }
@@ -791,50 +781,6 @@ export async function run<T = unknown>(
   return sandbox.run<T>(code, options);
 }
 
-interface IsolatedChildSuccess {
-  readonly ok: true;
-  readonly value: unknown;
-}
-
-interface IsolatedChildFailure {
-  readonly ok: false;
-  readonly error: {
-    readonly name: string;
-    readonly message: string;
-    readonly stack?: string;
-    readonly properties?: Record<string, unknown>;
-  };
-}
-
-type IsolatedChildResult = IsolatedChildSuccess | IsolatedChildFailure;
-
-const ISOLATED_ERROR_PROTOTYPES: Record<string, Error> = {
-  ExecutionAbortedError: ExecutionAbortedError.prototype,
-  FeatureError: FeatureError.prototype,
-  InterpreterError: InterpreterError.prototype,
-  ParseError: ParseError.prototype,
-  ResourceExhaustedError: ResourceExhaustedError.prototype,
-  RuntimeError: RuntimeError.prototype,
-  SecurityError: SecurityError.prototype,
-};
-
-const reconstructIsolatedError = (serialized: IsolatedChildFailure["error"]): Error => {
-  const error = new Error(serialized.message);
-  error.name = serialized.name;
-  error.stack = serialized.stack;
-
-  for (const [key, value] of Object.entries(serialized.properties ?? {})) {
-    (error as unknown as Record<string, unknown>)[key] = value;
-  }
-
-  const prototype = ISOLATED_ERROR_PROTOTYPES[serialized.name];
-  if (prototype) {
-    Object.setPrototypeOf(error, prototype);
-  }
-
-  return error;
-};
-
 export function runSyncIsolated<T = unknown>(
   code: string,
   options: IsolatedRunSyncOptionsFull,
@@ -847,105 +793,10 @@ export function runSyncIsolated<T = unknown>(
   validateTimeoutMs(options.timeoutMs);
   assertJsonSerializable("options", options);
 
-  const childInput = JSON.stringify({
-    code,
-    options,
-    moduleUrl: import.meta.url,
-  });
-
-  const childScript = `
-const input = JSON.parse(await Bun.stdin.text());
-const { createSandbox } = await import(input.moduleUrl);
-const cloneSerializable = (value, seen = new WeakSet()) => {
-  if (value === undefined || typeof value === "function" || typeof value === "symbol") {
-    return undefined;
-  }
-  if (typeof value === "bigint") {
-    return String(value);
-  }
-  if (typeof value === "number" && !Number.isFinite(value)) {
-    return String(value);
-  }
-  if (!value || typeof value !== "object") {
-    return value;
-  }
-  if (seen.has(value)) {
-    return "[Circular]";
-  }
-  seen.add(value);
-  if (Array.isArray(value)) {
-    return value.map((item) => cloneSerializable(item, seen));
-  }
-  const output = {};
-  for (const [key, nested] of Object.entries(value)) {
-    const cloned = cloneSerializable(nested, seen);
-    if (cloned !== undefined) {
-      output[key] = cloned;
-    }
-  }
-  seen.delete(value);
-  return output;
-};
-const writeFailure = (error) => {
-  const properties = error && typeof error === "object" ? cloneSerializable(error) : undefined;
-  const payload = {
-    ok: false,
-    error: {
-      name: error && typeof error === "object" && "name" in error ? error.name : "Error",
-      message: error instanceof Error ? error.message : String(error),
-      stack: error instanceof Error ? error.stack : undefined,
-      properties,
-    },
-  };
-  try {
-    process.stdout.write(JSON.stringify(payload));
-  } catch {
-    process.stdout.write(JSON.stringify({
-      ok: false,
-      error: {
-        name: payload.error.name,
-        message: payload.error.message,
-        stack: payload.error.stack,
-      },
-    }));
-  }
-};
-try {
-  const sandbox = createSandbox(input.options.sandbox);
-  const { sandbox: _sandbox, timeoutMs: _timeoutMs, ...runOptions } = input.options;
-  const value = sandbox.runSync(input.code, runOptions);
-  process.stdout.write(JSON.stringify({ ok: true, value }));
-} catch (error) {
-  writeFailure(error);
-  process.exitCode = 1;
-}
-`;
-
-  const result = spawnSync(process.execPath, ["--eval", childScript], {
-    input: childInput,
-    encoding: "utf8",
-    timeout: options.timeoutMs,
-    maxBuffer: 16 * 1024 * 1024,
-  });
-
-  if (result.error) {
-    if ((result.error as NodeJS.ErrnoException).code === "ETIMEDOUT") {
-      throw new ExecutionAbortedError();
-    }
-    throw result.error;
-  }
-
-  const output = result.stdout.trim();
-  if (!output) {
-    throw new Error(result.stderr.trim() || "Isolated sync execution failed");
-  }
-
-  const payload = JSON.parse(output) as IsolatedChildResult;
-  if (payload.ok) {
-    return payload.value as T | RunResult<T>;
-  }
-
-  throw reconstructIsolatedError(payload.error);
+  void code;
+  throw new Error(
+    "runSyncIsolated() is not available in the runtime-neutral package. Use async run() with timeoutMs/AbortSignal, or execute runSync() inside an application-owned worker or process.",
+  );
 }
 
 export const parse = (code: string, options?: ParseOnceOptions): ESTree.Program => {

--- a/test/sandbox-api.test.ts
+++ b/test/sandbox-api.test.ts
@@ -6,7 +6,7 @@ import { createSandbox, parse, run, runSyncIsolated } from "../src/sandbox";
 describe("Simplified API", () => {
   it("source should not import Node or Bun runtime-specific APIs", async () => {
     const nodeOrBunRuntimePattern =
-      /\bfrom\s+["']node:|\bfrom\s+["'](?:child_process|fs|path|os|crypto|buffer|process|worker_threads)["']|\brequire\(["']|\bprocess\.[A-Za-z_$]|\bBun\.|\bDeno\.|__dirname|__filename/;
+      /\bfrom\s+["']node:|\bfrom\s+["']bun:|\bfrom\s+["'](?:child_process|fs|path|os|crypto|buffer|process|worker_threads)["']|\brequire\(["']|\bprocess\.[A-Za-z_$]|\bBun\.|\bDeno\.|__dirname|__filename/;
     const sourceFiles = new Bun.Glob("src/**/*.ts").scan(".");
 
     for await (const path of sourceFiles) {

--- a/test/sandbox-api.test.ts
+++ b/test/sandbox-api.test.ts
@@ -1,9 +1,21 @@
 import { describe, it, expect } from "bun:test";
 
-import { InterpreterError, ResourceExhaustedError } from "../src";
+import { ResourceExhaustedError } from "../src";
 import { createSandbox, parse, run, runSyncIsolated } from "../src/sandbox";
 
 describe("Simplified API", () => {
+  it("source should not import Node or Bun runtime-specific APIs", async () => {
+    const nodeOrBunRuntimePattern =
+      /\bfrom\s+["']node:|\bfrom\s+["'](?:child_process|fs|path|os|crypto|buffer|process|worker_threads)["']|\brequire\(["']|\bprocess\.[A-Za-z_$]|\bBun\.|\bDeno\.|__dirname|__filename/;
+    const sourceFiles = new Bun.Glob("src/**/*.ts").scan(".");
+
+    for await (const path of sourceFiles) {
+      const contents = await Bun.file(path).text();
+      const executableContents = contents.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+      expect(executableContents, path).not.toMatch(nodeOrBunRuntimePattern);
+    }
+  });
+
   it("run() should evaluate code", async () => {
     const value = await run("1 + 2");
     expect(value).toBe(3);
@@ -609,54 +621,18 @@ describe("Simplified API", () => {
     );
   });
 
-  it("runSyncIsolated() should evaluate synchronous code with a timeout", () => {
-    const result = runSyncIsolated<number>("value * 2", {
-      timeoutMs: 1000,
-      sandbox: {
-        globals: { value: 21 },
-      },
-    });
-
-    expect(result).toBe(42);
-  });
-
-  it("runSyncIsolated() should hard-stop hostile synchronous code", () => {
+  it("runSyncIsolated() should reject runtime-neutral isolated execution", () => {
     expect(() =>
-      runSyncIsolated("while (true) {}", {
-        timeoutMs: 50,
-        sandbox: {
-          limits: { perRun: { loops: Number.MAX_SAFE_INTEGER } },
-        },
-      }),
-    ).toThrow("Execution aborted");
-  });
-
-  it("runSyncIsolated() should propagate child execution errors", () => {
-    expect(() =>
-      runSyncIsolated("missingValue + 1", {
-        timeoutMs: 1000,
-      }),
-    ).toThrow("Undefined variable");
-  });
-
-  it("runSyncIsolated() should preserve known child error identity", () => {
-    expect(() =>
-      runSyncIsolated("missingValue + 1", {
-        timeoutMs: 1000,
-      }),
-    ).toThrow(InterpreterError);
-
-    expect(() =>
-      runSyncIsolated("1 + 1", {
+      runSyncIsolated<number>("value * 2", {
         timeoutMs: 1000,
         sandbox: {
-          limits: { total: { evaluations: 0 } },
+          globals: { value: 21 },
         },
       }),
-    ).toThrow(ResourceExhaustedError);
+    ).toThrow("runSyncIsolated() is not available in the runtime-neutral package");
   });
 
-  it("runSyncIsolated() should require serializable options", () => {
+  it("runSyncIsolated() should still validate serializable options before rejecting runtime execution", () => {
     expect(() =>
       runSyncIsolated("1 + 1", {
         timeoutMs: 1000,
@@ -676,14 +652,6 @@ describe("Simplified API", () => {
         },
       }),
     ).toThrow("options must be JSON-serializable for isolated sync execution");
-  });
-
-  it("runSyncIsolated() should propagate errors with non-serializable thrown values", () => {
-    expect(() =>
-      runSyncIsolated("throw { nested: { fn: function () {} } }", {
-        timeoutMs: 1000,
-      }),
-    ).toThrow(InterpreterError);
   });
 
   it("runSyncIsolated() should reject non-finite numbers before JSON serialization", () => {


### PR DESCRIPTION
## Summary

Closes #223.

This removes Node/Bun runtime-specific process spawning from the runtime-neutral core package so `nookjs` can be bundled for browser and WinterCG environments without encountering `node:child_process`, `process.*`, or `Bun.*` APIs.

## Changes

- Removed the `spawnSync`-based `runSyncIsolated()` implementation from `src/sandbox.ts`.
- Kept the `runSyncIsolated()` export shape, but it now validates options and fails explicitly with guidance to use async timeout/AbortSignal or an application-owned Worker/process for hard-stop sync execution.
- Removed `global` fallback usage in presets and uses `globalThis` directly.
- Added a regression test that scans `src/**/*.ts` for Node/Bun runtime-specific APIs.
- Updated simplified API and security docs to describe host-owned isolation instead of Bun child-process isolation.
- Added a changeset for the compatibility-impacting package change.

## Impact

The core package no longer imports Node-only modules or embeds Bun/process APIs. Consumers that depended on the old process-backed `runSyncIsolated()` behavior will need to provide runtime-specific hard-stop isolation at the application layer.

## Validation

- `bun fmt`
- `bun lint:fix` (passes with existing warnings)
- `bun test`
- `bun typecheck`
- `bun run build`