### PR TITLE
[codex] fix async feature-control enforcement

### DIFF
--- a/.changeset/quiet-ducks-guard.md
+++ b/.changeset/quiet-ducks-guard.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Fix async evaluation feature-control enforcement for declarations, spread, destructuring, and destructuring defaults.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -11057,6 +11057,15 @@ export class Interpreter {
 
   private async evaluateVariableDeclarationAsync(node: ESTree.VariableDeclaration): Promise<any> {
     const kind = node.kind as "let" | "const" | "var";
+
+    // Check feature enablement based on declaration kind
+    if ((kind === "let" || kind === "const") && !this.isFeatureEnabled("LetConst")) {
+      throw new InterpreterError("LetConst is not enabled");
+    }
+    if (!this.isFeatureEnabled("VariableDeclarations")) {
+      throw new InterpreterError("VariableDeclarations is not enabled");
+    }
+
     this.validateVariableDeclarationKind(kind);
 
     let lastValue: any = undefined;
@@ -11813,6 +11822,10 @@ export class Interpreter {
     declare: boolean,
     kind?: "let" | "const" | "var",
   ): Promise<void> {
+    if (!this.isFeatureEnabled("Destructuring")) {
+      throw new InterpreterError("Destructuring is not enabled");
+    }
+
     if (pattern.type === "ArrayPattern") {
       await this.destructureArrayPatternAsync(pattern, value, declare, kind);
     } else if (pattern.type === "ObjectPattern") {
@@ -11965,6 +11978,10 @@ export class Interpreter {
     declare: boolean,
     kind?: "let" | "const" | "var",
   ): Promise<void> {
+    if (!this.isFeatureEnabled("DefaultParameters")) {
+      throw new InterpreterError("DefaultParameters is not enabled");
+    }
+
     // Use default if value is undefined
     const defaultExpr = pattern.right;
     if (!defaultExpr) {
@@ -12122,6 +12139,10 @@ export class Interpreter {
         elements.length += 1;
       } else if (element.type === "SpreadElement") {
         // Spread element: [...arr] - expand array into individual elements
+        if (!this.isFeatureEnabled("SpreadOperator")) {
+          throw new InterpreterError("SpreadOperator is not enabled");
+        }
+
         const spreadValue = await this.evaluateNodeAsync(
           (element as ESTree.SpreadElement).argument,
         );
@@ -12153,6 +12174,10 @@ export class Interpreter {
     for (const property of node.properties) {
       if (property.type === "SpreadElement") {
         // Spread element: {...obj} - expand object properties
+        if (!this.isFeatureEnabled("SpreadOperator")) {
+          throw new InterpreterError("SpreadOperator is not enabled");
+        }
+
         const spreadValue = await this.evaluateNodeAsync(
           (property as ESTree.SpreadElement).argument,
         );

--- a/test/feature-control.test.ts
+++ b/test/feature-control.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach } from "bun:test";
 
-import { Interpreter } from "../src/interpreter";
+import { Interpreter, type LanguageFeature } from "../src/interpreter";
 
 describe("Feature Control", () => {
   describe("API", () => {
@@ -819,6 +819,87 @@ describe("Feature Control", () => {
         expect(() => {
           interpreter.evaluate("async function foo() { return 42; }");
         }).not.toThrow();
+      });
+    });
+
+    describe("Async evaluation parity", () => {
+      const expectSyncAndAsyncToReject = async (
+        source: string,
+        disabledFeature: LanguageFeature,
+        message: string | RegExp,
+      ) => {
+        const syncInterpreter = new Interpreter({
+          featureControl: {
+            mode: "blacklist",
+            features: [disabledFeature],
+          },
+        });
+        const asyncInterpreter = new Interpreter({
+          featureControl: {
+            mode: "blacklist",
+            features: [disabledFeature],
+          },
+        });
+
+        expect(() => {
+          syncInterpreter.evaluate(source);
+        }).toThrow(message);
+
+        let asyncError: unknown;
+        try {
+          await asyncInterpreter.evaluateAsync(source);
+        } catch (error) {
+          asyncError = error;
+        }
+        expect(() => {
+          if (asyncError) {
+            throw asyncError;
+          }
+        }).toThrow(message);
+      };
+
+      test("blocks let and const declarations in async evaluation", async () => {
+        await expectSyncAndAsyncToReject("let x = 1; x;", "LetConst", "LetConst is not enabled");
+        await expectSyncAndAsyncToReject("const x = 1; x;", "LetConst", "LetConst is not enabled");
+      });
+
+      test("blocks variable declarations in async evaluation", async () => {
+        await expectSyncAndAsyncToReject(
+          "var x = 1; x;",
+          "VariableDeclarations",
+          "VariableDeclarations is not enabled",
+        );
+      });
+
+      test("blocks array and object spread in async evaluation", async () => {
+        await expectSyncAndAsyncToReject(
+          "[...[1, 2]];",
+          "SpreadOperator",
+          "SpreadOperator is not enabled",
+        );
+        await expectSyncAndAsyncToReject(
+          "({ ...{ x: 1 } });",
+          "SpreadOperator",
+          "SpreadOperator is not enabled",
+        );
+      });
+
+      test("blocks destructuring and destructuring defaults in async evaluation", async () => {
+        await expectSyncAndAsyncToReject(
+          "const [x] = [1]; x;",
+          "Destructuring",
+          "Destructuring is not enabled",
+        );
+        await expectSyncAndAsyncToReject(
+          "const [x = 1] = []; x;",
+          "DefaultParameters",
+          "DefaultParameters is not enabled",
+        );
+        await expectSyncAndAsyncToReject(
+          "const { x = 1 } = {}; x;",
+          "DefaultParameters",
+          "DefaultParameters is not enabled",
+        );
       });
     });
 


### PR DESCRIPTION
## Summary

Fixes #228.

This PR mirrors the sync evaluator's feature-control checks in the async evaluator so disabled syntax cannot bypass policy through `evaluateAsync()`.

## Root cause

The sync evaluator checked several feature gates at the point of evaluation, but the async counterparts skipped some of those checks:

- `evaluateVariableDeclarationAsync()` validated declaration kind but did not enforce `LetConst` or `VariableDeclarations`.
- `destructurePatternAsync()` did not enforce `Destructuring`.
- `handleAssignmentPatternAsync()` did not enforce `DefaultParameters` for destructuring defaults.
- async array/object literal evaluation expanded spread elements without checking `SpreadOperator`.

## Changes

- Added the missing async feature checks with the same error messages as the sync path.
- Added regression tests that compare sync and async rejection behavior for disabled `LetConst`, `VariableDeclarations`, `SpreadOperator`, `Destructuring`, and destructuring defaults.
- Added a patch changeset.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test test/feature-control.test.ts`
- `bun test`
- `bun lint`
- `bun typecheck`
- `bun fmt:check`