### PR TITLE
[codex] Enforce total resource limits immediately

### DIFF
--- a/.changeset/soft-spiders-scream.md
+++ b/.changeset/soft-spiders-scream.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Throw from the evaluation that exhausts total resource limits instead of delaying the error until the next evaluation.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -3284,15 +3284,20 @@ export class Interpreter {
     this.statsEndTime = performance.now();
 
     const currentMemoryUsage = this.getCurrentMemoryUsage();
+    let resourceError: unknown;
 
     if (this.integratedResourceTracker) {
       const cpuTimeMs = this.getCurrentEvaluationCpuTime(this.statsEndTime);
-      this.integratedResourceTracker.endEvaluation(
-        currentMemoryUsage,
-        this.statsLoopIterations,
-        this.statsFunctionCalls,
-        cpuTimeMs,
-      );
+      try {
+        this.integratedResourceTracker.endEvaluation(
+          currentMemoryUsage,
+          this.statsLoopIterations,
+          this.statsFunctionCalls,
+          cpuTimeMs,
+        );
+      } catch (error) {
+        resourceError = error;
+      }
     }
 
     // Always clean up per-call globals after execution.
@@ -3309,6 +3314,10 @@ export class Interpreter {
 
     // Clear execution control.
     this.executionCheckCounter = 0;
+
+    if (resourceError) {
+      throw resourceError;
+    }
   }
 
   private getCurrentEvaluationCpuTime(endTime = performance.now()): number {

--- a/src/resource-tracker.ts
+++ b/src/resource-tracker.ts
@@ -231,10 +231,17 @@ export class ResourceTracker {
       }
     }
 
-    this.checkLimits();
+    const exhaustedLimit = this.checkLimits();
+    if (exhaustedLimit) {
+      throw new ResourceExhaustedError(
+        exhaustedLimit,
+        this.getStats().limitStatus[exhaustedLimit]?.used ?? 0,
+        this.limits[exhaustedLimit] ?? 0,
+      );
+    }
   }
 
-  private checkLimits(): void {
+  private checkLimits(): keyof ResourceLimits | null {
     const stats = this.getStats();
 
     const preferredMemoryLimitStatus = stats.limitStatus[this.preferredMemoryLimitKey];
@@ -243,19 +250,21 @@ export class ResourceTracker {
       preferredMemoryLimitStatus.used >= preferredMemoryLimitStatus.limit
     ) {
       this.exhaustedLimit = this.preferredMemoryLimitKey;
-      return;
+      return this.preferredMemoryLimitKey;
     }
 
     for (const key of Object.keys(stats.limitStatus) as (keyof ResourceLimits)[]) {
-      if (key === "maxAllocationBytes" || key === "maxTotalMemory") {
+      if (key === "maxAllocationBytes" || key === "maxTotalMemory" || key === "maxEvaluations") {
         continue;
       }
       const status = stats.limitStatus[key];
       if (status && status.used >= status.limit) {
         this.exhaustedLimit = key;
-        return;
+        return key;
       }
     }
+
+    return null;
   }
 
   private syncMemoryLimitAliases(lastWritten?: "maxAllocationBytes" | "maxTotalMemory"): void {

--- a/test/resource-tracker.test.ts
+++ b/test/resource-tracker.test.ts
@@ -172,7 +172,7 @@ describe("Resource Tracking", () => {
           }
         });
 
-        test("should throw when maxTotalIterations exceeded", () => {
+        test("should throw during the evaluation that exceeds maxTotalIterations", () => {
           const interpreter = new Interpreter({
             ...ES2022,
             resourceTracking: true,
@@ -181,11 +181,12 @@ describe("Resource Tracking", () => {
 
           interpreter.evaluate("let sum = 0; for (let i = 0; i < 5; i++) { sum += i; }");
 
-          interpreter.evaluate("let sum2 = 0; for (let i = 0; i < 5; i++) { sum2 += i; }");
-
           expect(() => {
-            interpreter.evaluate("let sum3 = 0; for (let i = 0; i < 5; i++) { sum3 += i; }");
+            interpreter.evaluate("let sum2 = 0; for (let i = 0; i < 5; i++) { sum2 += i; }");
           }).toThrow(ResourceExhaustedError);
+
+          expect(interpreter.getResourceStats().evaluations).toBe(2);
+          expect(interpreter.getResourceHistory()).toHaveLength(2);
         });
 
         test("should reject the first evaluation when maxEvaluations is 0", () => {
@@ -238,24 +239,21 @@ describe("Resource Tracking", () => {
           expect(interpreter.getResourceStats().evaluations).toBe(3);
         });
 
-        test("should throw when maxFunctionCalls exceeded", () => {
+        test("should throw during the evaluation that exceeds maxFunctionCalls", () => {
           const interpreter = new Interpreter({
             ...ES2022,
             resourceTracking: true,
           });
           interpreter.setResourceLimit("maxFunctionCalls", 1);
 
-          interpreter.evaluate(`
+          expect(() => {
+            interpreter.evaluate(`
         function add(a, b) { return a + b; }
         add(1, 2);
       `);
-
-          expect(() => {
-            interpreter.evaluate(`
-          function double(x) { return x * 2; }
-          double(1);
-        `);
           }).toThrow(ResourceExhaustedError);
+
+          expect(interpreter.getResourceStats().functionCalls).toBeGreaterThanOrEqual(1);
         });
 
         test("should report correct exhausted limit", () => {
@@ -316,7 +314,7 @@ describe("Resource Tracking", () => {
           allocationTracker.setLimit("maxAllocationBytes", 5);
 
           allocationTracker.beginEvaluation();
-          allocationTracker.endEvaluation(5, 0, 0, 0);
+          expect(() => allocationTracker.endEvaluation(5, 0, 0, 0)).toThrow(ResourceExhaustedError);
 
           expect(allocationTracker.getExhaustedLimit()).toBe("maxAllocationBytes");
 
@@ -324,7 +322,9 @@ describe("Resource Tracking", () => {
           totalMemoryTracker.setLimit("maxTotalMemory", 5);
 
           totalMemoryTracker.beginEvaluation();
-          totalMemoryTracker.endEvaluation(5, 0, 0, 0);
+          expect(() => totalMemoryTracker.endEvaluation(5, 0, 0, 0)).toThrow(
+            ResourceExhaustedError,
+          );
 
           expect(totalMemoryTracker.getExhaustedLimit()).toBe("maxTotalMemory");
         });

--- a/test/sandbox-api.test.ts
+++ b/test/sandbox-api.test.ts
@@ -757,6 +757,7 @@ describe("Simplified API", () => {
 
     try {
       sandbox.runSync("const obj = { value: 1 }; obj;");
+      expect.unreachable("Expected memoryBytes total limit to be exceeded");
     } catch (error) {
       expect(error).toBeInstanceOf(ResourceExhaustedError);
       expect((error as ResourceExhaustedError).resourceType).toBe("maxTotalMemory");

--- a/test/sandbox-api.test.ts
+++ b/test/sandbox-api.test.ts
@@ -693,6 +693,41 @@ describe("Simplified API", () => {
     expect(() => sandbox.runSync("2 + 2")).toThrow("Resource limit exceeded");
   });
 
+  it("runSync() should reject the evaluation that exceeds a total memory limit", () => {
+    const sandbox = createSandbox({
+      env: "es2022",
+      limits: { total: { memoryBytes: 64 } },
+    });
+
+    expect(() => sandbox.runSync("const a = [1, 2, 3, 4, 5]; a.length")).toThrow(
+      ResourceExhaustedError,
+    );
+
+    const resources = sandbox.resources();
+    expect(resources?.evaluations).toBe(1);
+    expect(resources?.memoryBytes).toBeGreaterThan(64);
+    expect(resources?.isExhausted).toBe(true);
+  });
+
+  it("run() should reject the async evaluation that exceeds a total memory limit", async () => {
+    const sandbox = createSandbox({
+      env: "es2022",
+      limits: { total: { memoryBytes: 64 } },
+    });
+
+    try {
+      await sandbox.run("const a = [1, 2, 3, 4, 5]; a.length");
+      expect.unreachable("Expected async total memory limit to be exceeded");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ResourceExhaustedError);
+    }
+
+    const resources = sandbox.resources();
+    expect(resources?.evaluations).toBe(1);
+    expect(resources?.memoryBytes).toBeGreaterThan(64);
+    expect(resources?.isExhausted).toBe(true);
+  });
+
   it("should accept allocationBytes as the explicit cumulative memory budget alias", () => {
     const sandbox = createSandbox({
       env: "es2022",
@@ -720,10 +755,8 @@ describe("Simplified API", () => {
       limits: { total: { memoryBytes: 1 } },
     });
 
-    sandbox.runSync("const obj = { value: 1 }; obj;");
-
     try {
-      sandbox.runSync("const second = { value: 2 }; second;");
+      sandbox.runSync("const obj = { value: 1 }; obj;");
     } catch (error) {
       expect(error).toBeInstanceOf(ResourceExhaustedError);
       expect((error as ResourceExhaustedError).resourceType).toBe("maxTotalMemory");
@@ -736,10 +769,8 @@ describe("Simplified API", () => {
       limits: { total: { allocationBytes: 1 } },
     });
 
-    sandbox.runSync("const obj = { value: 1 }; obj;");
-
     try {
-      sandbox.runSync("const second = { value: 2 }; second;");
+      sandbox.runSync("const obj = { value: 1 }; obj;");
       expect.unreachable("Expected allocationBytes total limit to be exceeded");
     } catch (error) {
       expect(error).toBeInstanceOf(ResourceExhaustedError);


### PR DESCRIPTION
## Summary

Fixes #229 by making cumulative resource limit exhaustion throw from the evaluation that crosses the limit, instead of only marking the tracker as exhausted for the next evaluation.

## Changes

- Throw `ResourceExhaustedError` from `ResourceTracker.endEvaluation()` after stats and history have been recorded.
- Preserve interpreter cleanup before surfacing post-evaluation resource exhaustion errors.
- Keep `maxEvaluations` as an admission limit so exactly the configured number of evaluations remains allowed.
- Add sync and async sandbox regression coverage for total memory exhaustion and update resource tracker expectations.
- Add a patch changeset.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun typecheck`
- `bun test`
- `bun fmt:check`