### PR TITLE
fix: initialize default derived class fields

### DIFF
--- a/.changeset/gold-hounds-join.md
+++ b/.changeset/gold-hounds-join.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Initialize subclass fields when derived classes use the default constructor.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -13040,14 +13040,13 @@ export class Interpreter {
     // Evaluate arguments
     const args = this.evaluateArguments(argNodes);
 
-    // Find the constructor to call (could be inherited)
-    const { constructor, definingClass } = this.findClassConstructor(classValue);
+    const constructor = classValue.constructorMethod;
 
     // Execute constructor if there is one
     if (constructor) {
       const { result, thisValue } = this.executeClassConstructorBody(
         constructor,
-        definingClass,
+        classValue,
         instance,
         args,
       );
@@ -13088,12 +13087,12 @@ export class Interpreter {
 
     const args = await this.evaluateArgumentsAsync(argNodes);
 
-    const { constructor, definingClass } = this.findClassConstructor(classValue);
+    const constructor = classValue.constructorMethod;
 
     if (constructor) {
       const { result, thisValue } = await this.executeClassConstructorBodyAsync(
         constructor,
-        definingClass,
+        classValue,
         instance,
         args,
       );

--- a/test/classes.test.ts
+++ b/test/classes.test.ts
@@ -1759,6 +1759,40 @@ describe("Classes", () => {
         expect(result).toEqual([4, "Rex"]);
       });
 
+      it("should initialize derived fields when the derived class has no constructor", () => {
+        const interpreter = new Interpreter();
+        const result = interpreter.evaluate(`
+            class Parent {
+              constructor(value) {
+                this.parentValue = value;
+              }
+            }
+            class Child extends Parent {
+              childValue = this.parentValue + 1;
+            }
+            const child = new Child(41);
+            [child.parentValue, child.childValue];
+          `);
+        expect(result).toEqual([41, 42]);
+      });
+
+      it("should initialize async derived fields when the derived class has no constructor", async () => {
+        const interpreter = new Interpreter();
+        const result = await interpreter.evaluateAsync(`
+            class Parent {
+              constructor(value) {
+                this.parentValue = value;
+              }
+            }
+            class Child extends Parent {
+              childValue = this.parentValue + 1;
+            }
+            const child = new Child(41);
+            [child.parentValue, child.childValue];
+          `);
+        expect(result).toEqual([41, 42]);
+      });
+
       it("should allow child fields to override parent fields", () => {
         const interpreter = new Interpreter();
         const result = interpreter.evaluate(`
@@ -1931,6 +1965,42 @@ describe("Classes", () => {
             new User().getInfo();
           `);
         expect(result).toBe("John:123");
+      });
+
+      it("should initialize private derived fields when the derived class has no constructor", () => {
+        const interpreter = new Interpreter();
+        const result = interpreter.evaluate(`
+            class Parent {
+              constructor(value) {
+                this.parentValue = value;
+              }
+            }
+            class Child extends Parent {
+              #childValue = this.parentValue + 1;
+              getChildValue() { return this.#childValue; }
+            }
+            const child = new Child(41);
+            [child.parentValue, child.getChildValue()];
+          `);
+        expect(result).toEqual([41, 42]);
+      });
+
+      it("should initialize async private derived fields when the derived class has no constructor", async () => {
+        const interpreter = new Interpreter();
+        const result = await interpreter.evaluateAsync(`
+            class Parent {
+              constructor(value) {
+                this.parentValue = value;
+              }
+            }
+            class Child extends Parent {
+              #childValue = this.parentValue + 1;
+              getChildValue() { return this.#childValue; }
+            }
+            const child = new Child(41);
+            [child.parentValue, child.getChildValue()];
+          `);
+        expect(result).toEqual([41, 42]);
       });
 
       it("should throw when accessing private field outside class", () => {


### PR DESCRIPTION
Closes #231

## Summary
- Treat only the current class's own constructor as explicit during direct instantiation.
- Route derived classes without constructors through the synthesized super-constructor path so subclass instance fields are initialized after the parent constructor.
- Add sync and async regression coverage for default derived constructors with public and private fields.
- Add a patch changeset.

## Verification
- bun test test/classes.test.ts
- bun fmt
- bun lint:fix
- bun test
- bun typecheck
- bun fmt:check
- bun lint