### PR TITLE
[codex] Fix subclass static member inheritance

### DIFF
--- a/.changeset/tidy-owls-inherit.md
+++ b/.changeset/tidy-owls-inherit.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Inherit public static methods, accessors, and fields through subclass chains.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -13827,10 +13827,23 @@ export class Interpreter {
   ): any {
     this.validateDynamicPropertyKey(propertyName);
 
-    const setterResult = this.lookupClassMember(classValue, propertyName, "staticSetters");
-    if (setterResult) {
-      this.executeClassMethod(setterResult.member, classValue, setterResult.definingClass, [value]);
-      return value;
+    let current: ClassValue | null = classValue;
+    while (current) {
+      const setter = current.staticSetters.get(propertyName);
+      if (setter) {
+        this.executeClassMethod(setter, classValue, current, [value]);
+        return value;
+      }
+
+      if (
+        current.staticMethods.has(propertyName) ||
+        current.staticGetters.has(propertyName) ||
+        current.staticFields.has(propertyName)
+      ) {
+        break;
+      }
+
+      current = current.parentClass;
     }
 
     classValue.staticFields.set(propertyName, value);

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -13772,18 +13772,23 @@ export class Interpreter {
   private getClassStaticMember(classValue: ClassValue, propertyName: string | symbol): any {
     this.validateDynamicPropertyKey(propertyName);
 
-    const method = classValue.staticMethods.get(propertyName);
-    if (method) {
-      return method;
-    }
+    let current: ClassValue | null = classValue;
+    while (current) {
+      const method = current.staticMethods.get(propertyName);
+      if (method) {
+        return method;
+      }
 
-    const getter = classValue.staticGetters.get(propertyName);
-    if (getter) {
-      return this.executeClassMethod(getter, classValue, classValue, []);
-    }
+      const getter = current.staticGetters.get(propertyName);
+      if (getter) {
+        return this.executeClassMethod(getter, classValue, current, []);
+      }
 
-    if (classValue.staticFields.has(propertyName)) {
-      return classValue.staticFields.get(propertyName);
+      if (current.staticFields.has(propertyName)) {
+        return current.staticFields.get(propertyName);
+      }
+
+      current = current.parentClass;
     }
 
     return undefined;
@@ -13818,9 +13823,9 @@ export class Interpreter {
   ): any {
     this.validateDynamicPropertyKey(propertyName);
 
-    const setter = classValue.staticSetters.get(propertyName);
-    if (setter) {
-      this.executeClassMethod(setter, classValue, classValue, [value]);
+    const setterResult = this.lookupClassMember(classValue, propertyName, "staticSetters");
+    if (setterResult) {
+      this.executeClassMethod(setterResult.member, classValue, setterResult.definingClass, [value]);
       return value;
     }
 

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -13788,6 +13788,10 @@ export class Interpreter {
         return current.staticFields.get(propertyName);
       }
 
+      if (current.staticSetters.has(propertyName)) {
+        return undefined;
+      }
+
       current = current.parentClass;
     }
 

--- a/test/classes.test.ts
+++ b/test/classes.test.ts
@@ -1111,6 +1111,34 @@ describe("Classes", () => {
         expect(result).toEqual([1, 3]);
       });
 
+      it("should let setter-only static accessors shadow inherited static members", () => {
+        const interpreter = new Interpreter();
+        const result = interpreter.evaluate(`
+            class GetterBase {
+              static get value() {
+                return 1;
+              }
+            }
+            class GetterChild extends GetterBase {
+              static set value(next) {
+                this.received = next;
+              }
+            }
+
+            class FieldBase {
+              static value = 2;
+            }
+            class FieldChild extends FieldBase {
+              static set value(next) {
+                this.received = next;
+              }
+            }
+
+            [GetterChild.value, FieldChild.value];
+          `);
+        expect(result).toEqual([undefined, undefined]);
+      });
+
       it("should compute derived values with getters", () => {
         const interpreter = new Interpreter();
         const result = interpreter.evaluate(`

--- a/test/classes.test.ts
+++ b/test/classes.test.ts
@@ -1139,6 +1139,44 @@ describe("Classes", () => {
         expect(result).toEqual([undefined, undefined]);
       });
 
+      it("should not invoke inherited static setters when child static members shadow them", () => {
+        const interpreter = new Interpreter();
+        const result = interpreter.evaluate(`
+            class Base {
+              static calls = 0;
+              static set value(next) {
+                this.calls = this.calls + 1;
+              }
+            }
+
+            class FieldChild extends Base {
+              static value = 0;
+            }
+            FieldChild.value = 5;
+
+            class MethodChild extends Base {
+              static value() {
+                return 0;
+              }
+            }
+            MethodChild.value = 6;
+
+            class GetterChild extends Base {
+              static get value() {
+                return 0;
+              }
+            }
+            GetterChild.value = 7;
+
+            [FieldChild.value, MethodChild.value(), GetterChild.value, Base.calls];
+          `);
+
+        expect(result[0]).toBe(5);
+        expect(result[1]).toBe(0);
+        expect(result[2]).toBe(0);
+        expect(result[3]).toBe(0);
+      });
+
       it("should compute derived values with getters", () => {
         const interpreter = new Interpreter();
         const result = interpreter.evaluate(`

--- a/test/classes.test.ts
+++ b/test/classes.test.ts
@@ -1006,6 +1006,38 @@ describe("Classes", () => {
           `);
         expect(result).toEqual([0, 0]);
       });
+
+      it("should inherit static methods from parent classes", () => {
+        const interpreter = new Interpreter();
+        const result = interpreter.evaluate(`
+            class Base {
+              static value() {
+                return 1;
+              }
+            }
+            class Child extends Base {}
+            Child.value();
+          `);
+        expect(result).toBe(1);
+      });
+
+      it("should prefer child static methods over inherited static methods", () => {
+        const interpreter = new Interpreter();
+        const result = interpreter.evaluate(`
+            class Base {
+              static value() {
+                return 1;
+              }
+            }
+            class Child extends Base {
+              static value() {
+                return 2;
+              }
+            }
+            Child.value();
+          `);
+        expect(result).toBe(2);
+      });
     });
 
     describe("Getters and Setters", () => {
@@ -1058,6 +1090,25 @@ describe("Classes", () => {
             Config.version;
           `);
         expect(result).toBe("1.0.0");
+      });
+
+      it("should inherit static getters and setters from parent classes", () => {
+        const interpreter = new Interpreter();
+        const result = interpreter.evaluate(`
+            class Base {
+              static _value = 1;
+              static get value() {
+                return this._value;
+              }
+              static set value(next) {
+                this._value = next;
+              }
+            }
+            class Child extends Base {}
+            Child.value = 3;
+            [Base.value, Child.value];
+          `);
+        expect(result).toEqual([1, 3]);
       });
 
       it("should compute derived values with getters", () => {
@@ -1667,6 +1718,47 @@ describe("Classes", () => {
             Config.value;
           `);
         expect(result).toBe(undefined);
+      });
+
+      it("should inherit static fields from parent classes", () => {
+        const interpreter = new Interpreter();
+        const result = interpreter.evaluate(`
+            class Base {
+              static value = 2;
+            }
+            class Child extends Base {}
+            Child.value;
+          `);
+        expect(result).toBe(2);
+      });
+
+      it("should prefer child static fields over inherited static fields", () => {
+        const interpreter = new Interpreter();
+        const result = interpreter.evaluate(`
+            class Base {
+              static value = 2;
+            }
+            class Child extends Base {
+              static value = 4;
+            }
+            Child.value;
+          `);
+        expect(result).toBe(4);
+      });
+
+      it("should inherit static members in async evaluation", async () => {
+        const interpreter = new Interpreter();
+        const result = await interpreter.evaluateAsync(`
+            class Base {
+              static field = 2;
+              static method() {
+                return this.field;
+              }
+            }
+            class Child extends Base {}
+            Child.method();
+          `);
+        expect(result).toBe(2);
       });
 
       it("should evaluate instance field initializers for each instance", () => {


### PR DESCRIPTION
## Summary

Fixes #232.

Subclasses now resolve public static members through their parent class chain for direct class access such as `Child.method`, `Child.value`, and `Child.accessor`. Static lookup now checks each class in order before moving to its parent, so child static members continue to override inherited members.

Inherited static setters now use the same parent-chain lookup and execute with the subclass as the receiver. This preserves JavaScript constructor-prototype-chain behavior where assigning through an inherited static setter updates the subclass context rather than the parent.

## Validation

- `bun test test/classes.test.ts`
- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
- `bun fmt:check`
- `bun lint`

## Changeset

Added `.changeset/tidy-owls-inherit.md` for a patch release.