### PR TITLE
[codex] Support top-level await in async evaluation

### DIFF
--- a/.changeset/tidy-walls-wait.md
+++ b/.changeset/tidy-walls-wait.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Support top-level await in async script evaluation.

--- a/docs/ASYNC_AWAIT.md
+++ b/docs/ASYNC_AWAIT.md
@@ -12,6 +12,6 @@
 
 ## Gotchas
 
-- Top-level `await` is only supported in module evaluation (`runModule` / `evaluateModuleAsync`).
-- In non-module evaluation, `await` is only valid inside async functions.
+- Top-level `await` is supported in async script evaluation (`evaluateAsync` / `run`) and module evaluation (`evaluateModuleAsync` / `runModule`).
+- Synchronous `evaluate` rejects top-level `await`; use `evaluateAsync` for async snippets.
 - Calling async host functions in sync mode throws.

--- a/docs/FOR_OF_STATEMENT.md
+++ b/docs/FOR_OF_STATEMENT.md
@@ -13,5 +13,5 @@ Iterates over values of an iterable: `for (const x of iterable)`.
 
 ## Gotchas
 
-- `for await...of` is only supported in async evaluation and must be inside an async function (or module evaluation).
+- `for await...of` is only supported in async evaluation. It can be used inside async functions, at the top level of `evaluateAsync`, or in module evaluation.
 - Non-iterables throw.

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -5054,8 +5054,8 @@ export function parseModule(input: string): ESTree.Program {
   return parser.parseProgram("module");
 }
 
-export function parseScript(input: string): ESTree.Program {
-  const parser = new Parser(stripLeadingHashbang(input), false);
+export function parseScript(input: string, allowTopLevelAwait = false): ESTree.Program {
+  const parser = new Parser(stripLeadingHashbang(input), allowTopLevelAwait);
   return parser.parseProgram("script");
 }
 

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -3382,10 +3382,14 @@ export class Interpreter {
       }
 
       if (node.type === "AwaitExpression" && !inAsync) {
-        throw new InterpreterError("Unexpected token: await");
+        throw new InterpreterError(
+          "Cannot use await in synchronous evaluate(). Use evaluateAsync() instead.",
+        );
       }
       if (node.type === "ForOfStatement" && (node as ESTree.ForOfStatement).await && !inAsync) {
-        throw new InterpreterError("Unexpected token: await");
+        throw new InterpreterError(
+          "Cannot use for await...of in synchronous evaluate(). Use evaluateAsync() instead.",
+        );
       }
 
       if (
@@ -3418,11 +3422,17 @@ export class Interpreter {
   private parseAndValidate(
     input: string | ESTree.Program,
     options?: EvaluateOptions,
+    parseOptions?: { allowTopLevelAwait?: boolean },
   ): ESTree.Program {
-    const ast = typeof input === "string" ? parseScript(input) : input;
+    const ast =
+      typeof input === "string"
+        ? parseScript(input, parseOptions?.allowTopLevelAwait === true)
+        : input;
 
     this.validateAst(ast, options);
-    this.ensureNoTopLevelAwait(ast);
+    if (parseOptions?.allowTopLevelAwait !== true) {
+      this.ensureNoTopLevelAwait(ast);
+    }
 
     return ast;
   }
@@ -3455,7 +3465,8 @@ export class Interpreter {
       this.assertSyncSignalIsDisabled(options);
       this.beginEvaluation(options);
       evaluationStarted = true;
-      const ast = this.parseAndValidate(input, options);
+      const ast = this.parseAndValidate(input, options, { allowTopLevelAwait: true });
+      this.ensureNoTopLevelAwait(ast);
       const needsFreshScope = typeof input !== "string";
       const previousEnv = this.environment;
       if (needsFreshScope) {
@@ -3496,7 +3507,7 @@ export class Interpreter {
         throw new ExecutionAbortedError();
       }
 
-      const ast = this.parseAndValidate(input, options);
+      const ast = this.parseAndValidate(input, options, { allowTopLevelAwait: true });
       const needsFreshScope = typeof input !== "string";
       const previousEnv = this.environment;
       if (needsFreshScope) {
@@ -11644,7 +11655,7 @@ export class Interpreter {
     // 3. The host should treat returned values as opaque (documented security consideration)
 
     // Await the promise (or pass through non-promise values)
-    return await value;
+    return await this.withImmediateExecutionLimitCheckAsync(async () => value);
   }
 
   private async evaluateImportExpressionAsync(node: ESTree.ImportExpression): Promise<any> {

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -3465,8 +3465,9 @@ export class Interpreter {
       this.assertSyncSignalIsDisabled(options);
       this.beginEvaluation(options);
       evaluationStarted = true;
-      const ast = this.parseAndValidate(input, options, { allowTopLevelAwait: true });
+      const ast = typeof input === "string" ? parseScript(input, true) : input;
       this.ensureNoTopLevelAwait(ast);
+      this.validateAst(ast, options);
       const needsFreshScope = typeof input !== "string";
       const previousEnv = this.environment;
       if (needsFreshScope) {

--- a/test/ast-types.ts
+++ b/test/ast-types.ts
@@ -5,7 +5,9 @@ type Equal<A, B> =
 type Expect<T extends true> = T;
 
 type ParseScriptParams = Parameters<typeof parseScript>;
-type AssertParseScriptParams = Expect<Equal<ParseScriptParams, [input: string]>>;
+type AssertParseScriptParams = Expect<
+  Equal<ParseScriptParams, [input: string, allowTopLevelAwait?: boolean]>
+>;
 
 type ParseModuleParams = Parameters<typeof parseModule>;
 type AssertParseModuleParams = Expect<Equal<ParseModuleParams, [input: string]>>;

--- a/test/async.test.ts
+++ b/test/async.test.ts
@@ -98,6 +98,57 @@ describe("Async", () => {
       });
 
       describe("Basic async operations", () => {
+        it("should evaluate top-level await expressions", async () => {
+          const interpreter = new Interpreter();
+          const result = await interpreter.evaluateAsync("await Promise.resolve(1)");
+          expect(result).toBe(1);
+        });
+
+        it("should reject top-level await when the awaited promise rejects", async () => {
+          const interpreter = new Interpreter();
+          return expect(interpreter.evaluateAsync("await Promise.reject('boom')")).rejects.toThrow(
+            "boom",
+          );
+        });
+
+        it("should reject top-level await in synchronous evaluate", () => {
+          const interpreter = new Interpreter();
+          expect(() => interpreter.evaluate("await Promise.resolve(1)")).toThrow(
+            "Cannot use await in synchronous evaluate(). Use evaluateAsync() instead.",
+          );
+        });
+
+        it("should check abort signals around top-level await", async () => {
+          const controller = new AbortController();
+          const interpreter = new Interpreter({
+            globals: {
+              abortNow: () => {
+                controller.abort();
+                return Promise.resolve(1);
+              },
+            },
+          });
+
+          return expect(
+            interpreter.evaluateAsync("await abortNow()", { signal: controller.signal }),
+          ).rejects.toThrow("Execution aborted");
+        });
+
+        it("should enforce limits while evaluating top-level for await...of", async () => {
+          const interpreter = new Interpreter();
+
+          return expect(
+            interpreter.evaluateAsync(
+              `
+              for await (const value of [1, 2]) {
+                value;
+              }
+              `,
+              { maxLoopIterations: 1 },
+            ),
+          ).rejects.toThrow("Maximum loop iterations exceeded");
+        });
+
         it("should evaluate binary expressions", async () => {
           const interpreter = new Interpreter();
           expect(await interpreter.evaluateAsync("5 + 3")).toBe(8);
@@ -1088,6 +1139,18 @@ describe("Async", () => {
       });
 
       describe("sync iterables with for await", () => {
+        test("for await...of over regular array at the top level", async () => {
+          const interpreter = new Interpreter();
+          const result = await interpreter.evaluateAsync(`
+            const items = [];
+            for await (const val of [10, 20, 30]) {
+              items.push(val);
+            }
+            items
+          `);
+          expect(result).toEqual([10, 20, 30]);
+        });
+
         test("for await...of over regular array", async () => {
           const interpreter = new Interpreter();
           const result = await interpreter.evaluateAsync(`
@@ -1244,7 +1307,9 @@ describe("Async", () => {
             interpreter.evaluate(`
               for await (const val of [1, 2, 3]) {}
             `),
-          ).toThrow("Unexpected token: await");
+          ).toThrow(
+            "Cannot use for await...of in synchronous evaluate(). Use evaluateAsync() instead.",
+          );
         });
       });
 

--- a/test/modules.test.ts
+++ b/test/modules.test.ts
@@ -30,6 +30,25 @@ describe("Module System", () => {
   });
 
   describe("Basic Import/Export", () => {
+    test("should support top-level await in modules", async () => {
+      const interpreter = new Interpreter({
+        modules: {
+          enabled: true,
+          resolver: { resolve: () => null },
+        },
+      });
+
+      const exports = await interpreter.evaluateModuleAsync(
+        `
+        const value = await Promise.resolve(3);
+        export const result = value + 1;
+        `,
+        { path: "main.js" },
+      );
+
+      expect(exports.result).toBe(4);
+    });
+
     test("should export named constant", async () => {
       const files = new Map<string, string>([["math.js", "export const add = (a, b) => a + b;"]]);
 

--- a/test/sandbox-api.test.ts
+++ b/test/sandbox-api.test.ts
@@ -332,10 +332,11 @@ describe("Simplified API", () => {
     ).rejects.toThrow("Maximum loop iterations exceeded");
   });
 
-  it("run() should reject top-level await in scripts", async () => {
+  it("run() should allow top-level await in scripts", async () => {
     const sandbox = createSandbox({ env: "es2022" });
 
-    expect(sandbox.run("await Promise.resolve(1)")).rejects.toThrow();
+    const result = await sandbox.run("await Promise.resolve(1)");
+    expect(result).toBe(1);
   });
 
   it("runModule() should allow top-level await", async () => {

--- a/test/validator.test.ts
+++ b/test/validator.test.ts
@@ -49,6 +49,15 @@ describe("Validator", () => {
           expect(() => interpreter.evaluate("1 + 1")).toThrow("AST validation failed");
         });
 
+        it("should reject top-level await before running constructor validators in sync evaluate", () => {
+          const validator = () => false;
+
+          const interpreter = new Interpreter({ validator });
+          expect(() => interpreter.evaluate("await Promise.resolve(1)")).toThrow(
+            "Cannot use await in synchronous evaluate(). Use evaluateAsync() instead.",
+          );
+        });
+
         it("should work with no validator", () => {
           const interpreter = new Interpreter();
           expect(interpreter.evaluate("1 + 1")).toBe(2);
@@ -72,6 +81,15 @@ describe("Validator", () => {
 
           // Next call without validator works again
           expect(interpreter.evaluate("7 + 7")).toBe(14);
+        });
+
+        it("should reject top-level await before running per-call validators in sync evaluate", () => {
+          const interpreter = new Interpreter();
+          const strictValidator = () => false;
+
+          expect(() =>
+            interpreter.evaluate("await Promise.resolve(1)", { validator: strictValidator }),
+          ).toThrow("Cannot use await in synchronous evaluate(). Use evaluateAsync() instead.");
         });
 
         it("should allow different validators per call", () => {


### PR DESCRIPTION
## Summary

Fixes #233 by enabling top-level `await` in async script evaluation while keeping synchronous evaluation explicitly sync-only.

## What changed

- Allows `evaluateAsync()` and the async sandbox `run()` API to parse and execute top-level `await` in script input.
- Preserves `evaluate()` rejection for top-level `await` and `for await...of`, now with clearer messages that point callers to `evaluateAsync()`.
- Adds regression coverage for top-level await return values, rejection propagation, AbortSignal handling, loop limits, top-level `for await...of`, sandbox `run()`, and module evaluation behavior.
- Updates async/for-of docs and adds a patch changeset.

## Root cause

`evaluateAsync()` reused the script parser path with top-level await disabled, then `parseAndValidate()` always called `ensureNoTopLevelAwait()`. That made async script evaluation reject top-level await before the async evaluator could execute it.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
- `bun lint`
- `bun fmt:check`