### PR TITLE
[codex] fix object spread semantics

### DIFF
--- a/.changeset/friendly-spoons-spread.md
+++ b/.changeset/friendly-spoons-spread.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Match native object spread semantics for nullish values, arrays, and object-coercible primitives.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -5792,13 +5792,15 @@ export class Interpreter {
   }
 
   /**
-   * Validates that a spread value in an object expression is an object.
-   * Throws an error if the value is not a valid object.
+   * Converts an object spread value to the source object used for enumerable own property copying.
+   * Native object spread skips nullish values and object-coerces primitives.
    */
-  private validateObjectSpread(spreadValue: any): void {
-    if (typeof spreadValue !== "object" || spreadValue === null || Array.isArray(spreadValue)) {
-      throw new InterpreterError("Spread syntax in objects requires an object");
+  private objectSpreadSource(spreadValue: any): object | null {
+    if (spreadValue === null || spreadValue === undefined) {
+      return null;
     }
+
+    return Object(spreadValue);
   }
 
   private copyObjectSpreadProperties(target: Record<PropertyKey, any>, source: object): void {
@@ -10088,9 +10090,10 @@ export class Interpreter {
         }
 
         const spreadValue = this.evaluateNode((property as ESTree.SpreadElement).argument);
-        this.validateObjectSpread(spreadValue);
-
-        this.copyObjectSpreadProperties(obj, spreadValue);
+        const spreadSource = this.objectSpreadSource(spreadValue);
+        if (spreadSource !== null) {
+          this.copyObjectSpreadProperties(obj, spreadSource);
+        }
       } else if (property.type === "Property") {
         // Get the property key - evaluate expression for computed properties
         const computedKey = property.computed ? this.evaluateNode(property.key) : null;
@@ -12233,9 +12236,10 @@ export class Interpreter {
         const spreadValue = await this.evaluateNodeAsync(
           (property as ESTree.SpreadElement).argument,
         );
-        this.validateObjectSpread(spreadValue);
-
-        this.copyObjectSpreadProperties(obj, spreadValue);
+        const spreadSource = this.objectSpreadSource(spreadValue);
+        if (spreadSource !== null) {
+          this.copyObjectSpreadProperties(obj, spreadSource);
+        }
       } else if (property.type === "Property") {
         // Evaluate expression for computed properties
         const computedKey = property.computed ? await this.evaluateNodeAsync(property.key) : null;

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -1789,6 +1789,27 @@ describe("Objects", () => {
         expect(result).toEqual([123, 1, 1, 2]);
       });
 
+      it("should skip nullish values and copy array indexes with spread", () => {
+        const result = interpreter.evaluate(`
+          ({ ...null, ...undefined, ...["a", "b"], ok: true });
+        `);
+        expect(result).toEqual({ 0: "a", 1: "b", ok: true });
+      });
+
+      it("should object-coerce primitives with spread", () => {
+        const result = interpreter.evaluate(`
+          ({ ...123, ...false, ..."ab" });
+        `);
+        expect(result).toEqual({ 0: "a", 1: "b" });
+      });
+
+      it("should skip nullish values and copy array indexes with spread in evaluateAsync", async () => {
+        const result = await interpreter.evaluateAsync(`
+          ({ ...null, ...undefined, ...["a", "b"], ok: true });
+        `);
+        expect(result).toEqual({ 0: "a", 1: "b", ok: true });
+      });
+
       it("should count spread symbol keys against async memory limits", () => {
         return expect(
           interpreter.evaluateAsync(

--- a/test/objects.test.ts
+++ b/test/objects.test.ts
@@ -1810,6 +1810,13 @@ describe("Objects", () => {
         expect(result).toEqual({ 0: "a", 1: "b", ok: true });
       });
 
+      it("should object-coerce primitives with spread in evaluateAsync", async () => {
+        const result = await interpreter.evaluateAsync(`
+          ({ ...123, ...false, ..."ab" });
+        `);
+        expect(result).toEqual({ 0: "a", 1: "b" });
+      });
+
       it("should count spread symbol keys against async memory limits", () => {
         return expect(
           interpreter.evaluateAsync(

--- a/test/variables.test.ts
+++ b/test/variables.test.ts
@@ -1927,35 +1927,31 @@ describe("Variables", () => {
           expect(result).toEqual({ a: 1, b: 2 });
         });
 
-        it("should throw error when spreading array", () => {
+        it("should copy array indexes when spreading array", () => {
           const interpreter = new Interpreter();
-          expect(() => {
-            interpreter.evaluate(`({...[1, 2, 3]})`);
-          }).toThrow("Spread syntax in objects requires an object");
+          const result = interpreter.evaluate(`({...["a", "b"]})`);
+          expect(result).toEqual({ 0: "a", 1: "b" });
         });
 
-        it("should throw error when spreading null", () => {
+        it("should skip null when spreading object values", () => {
           const interpreter = new Interpreter();
-          expect(() => {
-            interpreter.evaluate(`({...null})`);
-          }).toThrow("Spread syntax in objects requires an object");
+          const result = interpreter.evaluate(`({...null, a: 1})`);
+          expect(result).toEqual({ a: 1 });
         });
 
-        it("should throw error when spreading undefined", () => {
+        it("should skip undefined when spreading object values", () => {
           const interpreter = new Interpreter();
-          expect(() => {
-            interpreter.evaluate(`
+          const result = interpreter.evaluate(`
               let x;
-              ({...x});
+              ({...x, a: 1});
             `);
-          }).toThrow("Spread syntax in objects requires an object");
+          expect(result).toEqual({ a: 1 });
         });
 
-        it("should throw error when spreading primitive (number)", () => {
+        it("should object-coerce primitives when spreading object values", () => {
           const interpreter = new Interpreter();
-          expect(() => {
-            interpreter.evaluate(`({...5})`);
-          }).toThrow("Spread syntax in objects requires an object");
+          const result = interpreter.evaluate(`({...5, ..."ab", ...true})`);
+          expect(result).toEqual({ 0: "a", 1: "b" });
         });
 
         it("should spread object from function return", () => {


### PR DESCRIPTION
## Summary

Fixes #234 by matching native JavaScript object spread behavior for nullish values, arrays, and object-coercible primitives.

## What changed

Object spread now skips `null` and `undefined` sources instead of throwing. Non-nullish spread sources are coerced with `Object(...)` before copying enumerable own properties, so arrays contribute their enumerable index properties and strings contribute their character indexes. The existing property-name validation remains in the property copy path, preserving prototype-pollution protections for dangerous string keys.

## Impact

Interpreter users can now evaluate object spread expressions that native JavaScript accepts, including `({ ...null, ...undefined, a: 1 })`, `({ ...['a', 'b'] })`, and primitive object-spread cases such as strings.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun test`
- `bun typecheck`
- `bun fmt:check`