### PR TITLE
fix: track function constructor instances

### DIFF
--- a/.changeset/gentle-bees-construct.md
+++ b/.changeset/gentle-bees-construct.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Track interpreted function constructor instances for `instanceof` checks.

--- a/docs/BINARY_OPERATORS.md
+++ b/docs/BINARY_OPERATORS.md
@@ -23,6 +23,7 @@ Binary operations such as `+`, `-`, comparisons, bitwise operators, and `**`.
 
 - `in` requires the right-hand side to be an object.
 - `instanceof` supports host constructors, `ClassValue`, and `FunctionValue` instances.
+- `FunctionValue` `instanceof` uses constructor metadata, not `Function.prototype` chain semantics.
 - Division/modulo by zero defaults to `numericSemantics: "safe"` and throws an `InterpreterError`.
   Set `numericSemantics: "strict-js"` to use native JS results (`Infinity`, `-Infinity`, `NaN`).
 - String concatenation with `+` coerces the other operand to a string.

--- a/docs/NEW_EXPRESSION.md
+++ b/docs/NEW_EXPRESSION.md
@@ -8,10 +8,12 @@ Constructor calls like `new Foo()`.
 
 - Implemented in `evaluateNewExpression` / `evaluateNewExpressionAsync`.
 - Supports `FunctionValue`, `HostFunctionValue`, and `ClassValue`.
-- Instances are plain objects (no prototype chain).
+- `FunctionValue` and `ClassValue` instances are plain objects (no native prototype chain).
 - Host constructor returns are wrapped in `ReadOnlyProxy`.
 
 ## Gotchas
 
 - No native prototype chain; `instanceof` uses interpreter metadata.
+- Function constructors track only the constructor that created the default instance object. The
+  interpreter does not model `Function.prototype` or custom prototype chains.
 - If a constructor returns an object, it replaces the created instance.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -148,7 +148,7 @@ export class FunctionValue {
     public homeIsStatic: boolean = false, // Whether the method is static
     public destructuredParams: Map<number, ESTree.ObjectPattern | ESTree.ArrayPattern> = new Map(), // Destructuring patterns by param index
     public isArrowFunction: boolean = false, // Arrow functions capture lexical this/arguments
-    public lexicalThisValue: any = undefined, // Captured this at arrow creation time
+    public lexicalThisValue?: any, // Captured this at arrow creation time
   ) {}
 }
 
@@ -2006,7 +2006,7 @@ class Environment {
 
   constructor(
     parent: Environment | null = null,
-    thisValue: any = undefined,
+    thisValue?: any,
     isFunctionScope: boolean = false,
   ) {
     this.parent = parent;
@@ -2679,6 +2679,7 @@ export class Interpreter {
   // Track super binding context during class method execution
   private currentSuperBinding: SuperBinding | null = null;
   private instanceClassMap: WeakMap<object, ClassValue> = new WeakMap();
+  private instanceFunctionMap: WeakMap<object, FunctionValue> = new WeakMap();
   private sandboxOwnedContainers: WeakSet<object> = new WeakSet();
   private sandboxPrototypeLinkedContainers: WeakSet<object> = new WeakSet();
   private arrayMethodCache: WeakMap<any[], Map<string, HostFunctionValue>> = new WeakMap();
@@ -6296,11 +6297,11 @@ export class Interpreter {
    * Check if an object is an instance of a FunctionValue (user-defined constructor).
    * This is for functions used as constructors with 'new'.
    */
-  private isInstanceOfFunction(_obj: any, _funcValue: FunctionValue): boolean {
-    // FunctionValue instances used as constructors aren't tracked the same way
-    // as ClassValue instances. For now, return false.
-    // This could be extended if we track function-based construction.
-    return false;
+  private isInstanceOfFunction(obj: any, funcValue: FunctionValue): boolean {
+    if (typeof obj !== "object" || obj === null) {
+      return false;
+    }
+    return this.instanceFunctionMap.get(obj) === funcValue;
   }
 
   /**
@@ -8988,6 +8989,7 @@ export class Interpreter {
 
       // Validate argument count
       this.validateFunctionArguments(callee, args);
+      this.instanceFunctionMap.set(instance, callee);
 
       // Execute with instance as 'this'
       result = this.executeSandboxFunction(callee, args, instance);
@@ -10547,6 +10549,7 @@ export class Interpreter {
 
       // Validate argument count
       this.validateFunctionArguments(callee, args);
+      this.instanceFunctionMap.set(instance, callee);
 
       // Execute with instance as 'this'
       result = await this.executeSandboxFunctionAsync(callee, args, instance);

--- a/test/operators.test.ts
+++ b/test/operators.test.ts
@@ -1039,6 +1039,66 @@ describe("Operators", () => {
         });
       });
 
+      describe("With user-defined function constructors", () => {
+        test("returns true for objects created by the constructor", () => {
+          expect(
+            interpreter.evaluate(`
+              function F() {}
+              const f = new F();
+              f instanceof F;
+            `),
+          ).toBe(true);
+        });
+
+        test("tracks multiple constructors independently", () => {
+          expect(
+            interpreter.evaluate(`
+              function A() {}
+              function B() {}
+              const a = new A();
+              const b = new B();
+              a instanceof A && !(a instanceof B) && b instanceof B && !(b instanceof A);
+            `),
+          ).toBe(true);
+        });
+
+        test("does not confuse class instances with function constructor instances", () => {
+          expect(
+            interpreter.evaluate(`
+              function F() {}
+              class C {}
+              const f = new F();
+              const c = new C();
+              f instanceof F && !(f instanceof C) && c instanceof C && !(c instanceof F);
+            `),
+          ).toBe(true);
+        });
+
+        test("constructor object returns override the tracked instance", () => {
+          expect(
+            interpreter.evaluate(`
+              function F() {
+                return {};
+              }
+              const f = new F();
+              f instanceof F;
+            `),
+          ).toBe(false);
+        });
+
+        test("constructor primitive returns keep the tracked instance", () => {
+          expect(
+            interpreter.evaluate(`
+              function F() {
+                return 1;
+              }
+              const f = new F();
+              f instanceof F;
+            `),
+          ).toBe(true);
+        });
+      });
+
       describe("Primitives", () => {
         test("number is not instanceof Number", () => {
           expect(
@@ -1174,6 +1234,17 @@ describe("Operators", () => {
           const result = await interpreter.evaluateAsync("({a:1}) instanceof Object", {
             globals: { Object },
           });
+          expect(result).toBe(true);
+        });
+
+        test("async supports user-defined function constructors", async () => {
+          const result = await interpreter.evaluateAsync(`
+            function F() {
+              this.x = 1;
+            }
+            const f = new F();
+            f instanceof F && f.x === 1;
+          `);
           expect(result).toBe(true);
         });
       });


### PR DESCRIPTION
## Summary

Fixes #236 by tracking objects created by interpreted `FunctionValue` constructors so `new F() instanceof F` returns `true`.

## Changes

- Add `FunctionValue` constructor instance metadata separate from `ClassValue` instance metadata.
- Preserve native-like constructor return behavior: returned objects replace the tracked default instance and therefore are not `instanceof` the original constructor.
- Add regression coverage for multiple constructors, class/function separation, primitive/object constructor returns, and async evaluation.
- Document that function-constructor `instanceof` uses interpreter metadata, not full `Function.prototype` chain semantics.
- Add a patch changeset.

## Verification

- `bun test test/operators.test.ts`
- `bun fmt`
- `bun lint:fix` (exits 0; reports two existing `no-unreachable` warnings in `test/security.test.ts`)
- `bun test`
- `bun typecheck`
- `bun lint` (exits 0; reports the same two existing `no-unreachable` warnings in `test/security.test.ts`)
- `bun fmt:check`