### PR TITLE
[codex] Fix memory accounting for built-in allocations

### DIFF
--- a/.changeset/sour-ducks-allocate.md
+++ b/.changeset/sour-ducks-allocate.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Track memory for allocating array and string built-ins plus materialized host return containers.

--- a/docs/RESOURCE_ATTRIBUTION.md
+++ b/docs/RESOURCE_ATTRIBUTION.md
@@ -342,7 +342,11 @@ Memory tracking is a best-effort estimate based on:
 
 - Array allocations: ~16 bytes per element
 - Object allocations: ~64 bytes base + 32 bytes per property
-- String allocations (via template literals): ~2 bytes per character
+- String allocations: ~2 bytes per character
+
+The interpreter applies this best-effort strategy to observable literal allocations, common
+allocating array and string built-ins, destructuring rest containers, function `arguments`/rest
+parameter arrays, and arrays or plain objects materialized from host return values.
 
 This is not precise memory accounting but serves to detect runaway allocations.
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -440,7 +440,11 @@ Limits estimated memory usage in bytes. This is a **best-effort heuristic** that
 
 - Array allocations: ~16 bytes per element
 - Object allocations: ~64 bytes base + 32 bytes per property
-- String allocations (via template literals): ~2 bytes per character
+- String allocations: ~2 bytes per character
+
+The same accounting strategy is applied to allocations the interpreter can observe outside literals,
+including common array and string built-in methods, destructuring rest containers, function
+`arguments`/rest parameter arrays, and arrays or plain objects materialized from host return values.
 
 When exceeded, throws `InterpreterError: Maximum memory limit exceeded`.
 

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -3167,7 +3167,11 @@ export class Interpreter {
   }
 
   private shouldRethrowExecutionControlError(error: unknown): boolean {
-    return error instanceof ResourceExhaustedError || error instanceof ExecutionAbortedError;
+    return (
+      error instanceof ResourceExhaustedError ||
+      error instanceof ExecutionAbortedError ||
+      error instanceof InterpreterError
+    );
   }
 
   /**
@@ -3239,6 +3243,22 @@ export class Interpreter {
     if (currentMemoryUsage > maxMemory) {
       throw new InterpreterError("Maximum memory limit exceeded");
     }
+  }
+
+  /**
+   * Best-effort allocation accounting for containers and strings created outside
+   * literal/template evaluators, such as built-ins and materialized host returns.
+   */
+  private trackArrayAllocation(value: readonly unknown[]): void {
+    this.trackMemory(value.length * 16);
+  }
+
+  private trackObjectAllocation(value: object): void {
+    this.trackMemory(64 + Reflect.ownKeys(value).length * 32);
+  }
+
+  private trackStringAllocation(value: string): void {
+    this.trackMemory(value.length * 2);
   }
 
   private beginEvaluation(options?: EvaluateOptions): void {
@@ -5502,7 +5522,9 @@ export class Interpreter {
   public bindFunctionParameters(fn: FunctionValue, args: any[]): void {
     if (!fn.isArrowFunction && !fn.params.includes("arguments")) {
       // Non-arrow functions get their own arguments object.
-      this.environment.declare("arguments", this.markSandboxContainer(args.slice()), "var");
+      const argumentsObject = args.slice();
+      this.trackArrayAllocation(argumentsObject);
+      this.environment.declare("arguments", this.markSandboxContainer(argumentsObject), "var");
     }
 
     const regularParamCount = fn.restParamIndex !== null ? fn.restParamIndex : fn.params.length;
@@ -5529,7 +5551,9 @@ export class Interpreter {
     // Bind rest parameter if present
     if (fn.restParamIndex !== null) {
       const restParamName = fn.params[fn.restParamIndex]!;
-      const restArgs = this.markSandboxContainer(args.slice(fn.restParamIndex));
+      const restArgs = args.slice(fn.restParamIndex);
+      this.trackArrayAllocation(restArgs);
+      this.markSandboxContainer(restArgs);
       this.environment.declare(restParamName, restArgs, "let");
     }
   }
@@ -5541,7 +5565,9 @@ export class Interpreter {
   public async bindFunctionParametersAsync(fn: FunctionValue, args: any[]): Promise<void> {
     if (!fn.isArrowFunction && !fn.params.includes("arguments")) {
       // Non-arrow functions get their own arguments object.
-      this.environment.declare("arguments", this.markSandboxContainer(args.slice()), "var");
+      const argumentsObject = args.slice();
+      this.trackArrayAllocation(argumentsObject);
+      this.environment.declare("arguments", this.markSandboxContainer(argumentsObject), "var");
     }
 
     const regularParamCount = fn.restParamIndex !== null ? fn.restParamIndex : fn.params.length;
@@ -5568,7 +5594,9 @@ export class Interpreter {
     // Bind rest parameter if present
     if (fn.restParamIndex !== null) {
       const restParamName = fn.params[fn.restParamIndex]!;
-      const restArgs = this.markSandboxContainer(args.slice(fn.restParamIndex));
+      const restArgs = args.slice(fn.restParamIndex);
+      this.trackArrayAllocation(restArgs);
+      this.markSandboxContainer(restArgs);
       this.environment.declare(restParamName, restArgs, "let");
     }
   }
@@ -5624,8 +5652,7 @@ export class Interpreter {
       }
     }
 
-    // Track memory: estimate 2 bytes per character (UTF-16)
-    this.trackMemory(result.length * 2);
+    this.trackStringAllocation(result);
 
     return result;
   }
@@ -6189,6 +6216,7 @@ export class Interpreter {
       seen.set(value, materialized);
       this.markSandboxContainer(materialized);
       materialized.length = value.length;
+      this.trackArrayAllocation(materialized);
 
       for (const key of Reflect.ownKeys(descriptors)) {
         if (key === "length") {
@@ -6250,6 +6278,7 @@ export class Interpreter {
         );
       }
 
+      this.trackObjectAllocation(materialized);
       return materialized;
     }
 
@@ -6456,6 +6485,7 @@ export class Interpreter {
       }
       result.push(iterResult.value);
     }
+    this.trackArrayAllocation(result);
     return result;
   }
 
@@ -8741,6 +8771,7 @@ export class Interpreter {
         }
       }
 
+      this.trackObjectAllocation(restObj);
       this.bindDestructuredIdentifier(restName, restObj, declare, kind);
     }
   }
@@ -9330,13 +9361,25 @@ export class Interpreter {
       // Non-mutation methods
       case "slice":
         return this.createHostFunction(
-          (start?: number, end?: number) => arr.slice(start, end),
+          (start?: number, end?: number) => {
+            const result = arr.slice(start, end);
+            this.trackArrayAllocation(result);
+            return this.markSandboxContainer(result);
+          },
           "slice",
           false,
         );
 
       case "concat":
-        return this.createHostFunction((...items: any[]) => arr.concat(...items), "concat", false);
+        return this.createHostFunction(
+          (...items: any[]) => {
+            const result = arr.concat(...items);
+            this.trackArrayAllocation(result);
+            return this.markSandboxContainer(result);
+          },
+          "concat",
+          false,
+        );
 
       case "indexOf":
         return this.createHostFunction(
@@ -9353,7 +9396,15 @@ export class Interpreter {
         );
 
       case "join":
-        return this.createHostFunction((separator?: string) => arr.join(separator), "join", false);
+        return this.createHostFunction(
+          (separator?: string) => {
+            const result = arr.join(separator);
+            this.trackStringAllocation(result);
+            return result;
+          },
+          "join",
+          false,
+        );
 
       case "reverse":
         return this.createHostFunction(() => arr.reverse(), "reverse", false);
@@ -9373,7 +9424,8 @@ export class Interpreter {
               const value = this.callCallback(callback, thisArg, [arr[i], i, arr]);
               result[i] = value;
             }
-            return result;
+            this.trackArrayAllocation(result);
+            return this.markSandboxContainer(result);
           },
           "map",
           false,
@@ -9395,7 +9447,8 @@ export class Interpreter {
                 result.push(arr[i]);
               }
             }
-            return result;
+            this.trackArrayAllocation(result);
+            return this.markSandboxContainer(result);
           },
           "filter",
           false,
@@ -9549,7 +9602,15 @@ export class Interpreter {
         );
 
       case "flat":
-        return this.createHostFunction((depth?: number) => arr.flat(depth), "flat", false);
+        return this.createHostFunction(
+          (depth?: number) => {
+            const result = arr.flat(depth);
+            this.trackArrayAllocation(result);
+            return this.markSandboxContainer(result);
+          },
+          "flat",
+          false,
+        );
 
       case "flatMap":
         return this.createHostFunction(
@@ -9571,7 +9632,8 @@ export class Interpreter {
                 result.push(mapped);
               }
             }
-            return result;
+            this.trackArrayAllocation(result);
+            return this.markSandboxContainer(result);
           },
           "flatMap",
           false,
@@ -9649,10 +9711,12 @@ export class Interpreter {
       case "splice":
         return this.createHostFunction(
           (start: number, deleteCount?: number, ...items: any[]) => {
-            if (deleteCount === undefined) {
-              return arr.splice(start);
-            }
-            return arr.splice(start, deleteCount, ...items);
+            const result =
+              deleteCount === undefined
+                ? arr.splice(start)
+                : arr.splice(start, deleteCount, ...items);
+            this.trackArrayAllocation(result);
+            return this.markSandboxContainer(result);
           },
           "splice",
           false,
@@ -9707,7 +9771,9 @@ export class Interpreter {
       case "substring":
         return this.createHostFunction(
           (start: number, end?: number) => {
-            return str.substring(start, end);
+            const result = str.substring(start, end);
+            this.trackStringAllocation(result);
+            return result;
           },
           "substring",
           false,
@@ -9716,7 +9782,9 @@ export class Interpreter {
       case "slice":
         return this.createHostFunction(
           (start: number, end?: number) => {
-            return str.slice(start, end);
+            const result = str.slice(start, end);
+            this.trackStringAllocation(result);
+            return result;
           },
           "slice",
           false,
@@ -9725,7 +9793,9 @@ export class Interpreter {
       case "charAt":
         return this.createHostFunction(
           (index: number) => {
-            return str.charAt(index);
+            const result = str.charAt(index);
+            this.trackStringAllocation(result);
+            return result;
           },
           "charAt",
           false,
@@ -9782,7 +9852,9 @@ export class Interpreter {
       case "toUpperCase":
         return this.createHostFunction(
           () => {
-            return str.toUpperCase();
+            const result = str.toUpperCase();
+            this.trackStringAllocation(result);
+            return result;
           },
           "toUpperCase",
           false,
@@ -9791,7 +9863,9 @@ export class Interpreter {
       case "toLowerCase":
         return this.createHostFunction(
           () => {
-            return str.toLowerCase();
+            const result = str.toLowerCase();
+            this.trackStringAllocation(result);
+            return result;
           },
           "toLowerCase",
           false,
@@ -9801,7 +9875,9 @@ export class Interpreter {
       case "trim":
         return this.createHostFunction(
           () => {
-            return str.trim();
+            const result = str.trim();
+            this.trackStringAllocation(result);
+            return result;
           },
           "trim",
           false,
@@ -9811,7 +9887,9 @@ export class Interpreter {
       case "trimLeft":
         return this.createHostFunction(
           () => {
-            return str.trimStart();
+            const result = str.trimStart();
+            this.trackStringAllocation(result);
+            return result;
           },
           "trimStart",
           false,
@@ -9821,7 +9899,9 @@ export class Interpreter {
       case "trimRight":
         return this.createHostFunction(
           () => {
-            return str.trimEnd();
+            const result = str.trimEnd();
+            this.trackStringAllocation(result);
+            return result;
           },
           "trimEnd",
           false,
@@ -9831,13 +9911,19 @@ export class Interpreter {
       case "split":
         return this.createHostFunction(
           (separator?: string | RegExp | null, limit?: number) => {
+            let result: string[];
             if (separator === undefined) {
-              return [str];
+              result = [str];
+            } else if (separator === null) {
+              result = str.split("null", limit);
+            } else {
+              result = str.split(separator, limit);
             }
-            if (separator === null) {
-              return str.split("null", limit);
+            this.trackArrayAllocation(result);
+            for (const part of result) {
+              this.trackStringAllocation(part);
             }
-            return str.split(separator, limit);
+            return this.markSandboxContainer(result);
           },
           "split",
           false,
@@ -9846,7 +9932,9 @@ export class Interpreter {
       case "replace":
         return this.createHostFunction(
           (searchValue: string, replaceValue: string) => {
-            return str.replace(searchValue, replaceValue);
+            const result = str.replace(searchValue, replaceValue);
+            this.trackStringAllocation(result);
+            return result;
           },
           "replace",
           false,
@@ -9855,7 +9943,9 @@ export class Interpreter {
       case "repeat":
         return this.createHostFunction(
           (count: number) => {
-            return str.repeat(count);
+            const result = str.repeat(count);
+            this.trackStringAllocation(result);
+            return result;
           },
           "repeat",
           false,
@@ -9865,7 +9955,9 @@ export class Interpreter {
       case "padStart":
         return this.createHostFunction(
           (targetLength: number, padString?: string) => {
-            return str.padStart(targetLength, padString);
+            const result = str.padStart(targetLength, padString);
+            this.trackStringAllocation(result);
+            return result;
           },
           "padStart",
           false,
@@ -9874,7 +9966,9 @@ export class Interpreter {
       case "padEnd":
         return this.createHostFunction(
           (targetLength: number, padString?: string) => {
-            return str.padEnd(targetLength, padString);
+            const result = str.padEnd(targetLength, padString);
+            this.trackStringAllocation(result);
+            return result;
           },
           "padEnd",
           false,
@@ -10094,8 +10188,7 @@ export class Interpreter {
       }
     }
 
-    // Track memory: estimate 16 bytes per array element
-    this.trackMemory(elements.length * 16);
+    this.trackArrayAllocation(elements);
 
     return this.markSandboxContainer(elements);
   }
@@ -10158,9 +10251,7 @@ export class Interpreter {
       }
     }
 
-    // Track memory: estimate 64 bytes base + 32 bytes per property
-    const propertyCount = Reflect.ownKeys(obj).length;
-    this.trackMemory(64 + propertyCount * 32);
+    this.trackObjectAllocation(obj);
 
     return this.markSandboxContainer(obj);
   }
@@ -12049,6 +12140,7 @@ export class Interpreter {
         }
       }
 
+      this.trackObjectAllocation(restObj);
       this.bindDestructuredIdentifier(restName, restObj, declare, kind);
     }
   }
@@ -12242,8 +12334,7 @@ export class Interpreter {
       }
     }
 
-    // Track memory: estimate 16 bytes per array element
-    this.trackMemory(elements.length * 16);
+    this.trackArrayAllocation(elements);
 
     return this.markSandboxContainer(elements);
   }
@@ -12308,9 +12399,7 @@ export class Interpreter {
       }
     }
 
-    // Track memory: estimate 64 bytes base + 32 bytes per property
-    const propertyCount = Reflect.ownKeys(obj).length;
-    this.trackMemory(64 + propertyCount * 32);
+    this.trackObjectAllocation(obj);
 
     return this.markSandboxContainer(obj);
   }

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -9920,8 +9920,10 @@ export class Interpreter {
               result = str.split(separator, limit);
             }
             this.trackArrayAllocation(result);
-            for (const part of result) {
-              this.trackStringAllocation(part);
+            if (separator !== undefined) {
+              for (const part of result) {
+                this.trackStringAllocation(part);
+              }
             }
             return this.markSandboxContainer(result);
           },

--- a/test/execution-control.test.ts
+++ b/test/execution-control.test.ts
@@ -309,6 +309,47 @@ describe("Execution Control", () => {
           }).toThrow("Maximum memory limit exceeded");
         });
 
+        test("should throw when array methods allocate beyond memory limit", () => {
+          const interpreter = new Interpreter();
+          expect(() => {
+            interpreter.evaluate(
+              `
+          const base = [1, 2, 3, 4, 5];
+          for (let i = 0; i < 100; i++) {
+            base.map((value) => value * 2);
+          }
+        `,
+              { maxMemory: 1000, maxLoopIterations: 100000 },
+            );
+          }).toThrow("Maximum memory limit exceeded");
+        });
+
+        test("should throw when string methods allocate beyond memory limit", () => {
+          const interpreter = new Interpreter();
+          expect(() => {
+            interpreter.evaluate(
+              `
+          const base = "hello";
+          for (let i = 0; i < 100; i++) {
+            base.repeat(10);
+          }
+        `,
+              { maxMemory: 1000, maxLoopIterations: 100000 },
+            );
+          }).toThrow("Maximum memory limit exceeded");
+        });
+
+        test("should throw when materialized host returns exceed memory limit", () => {
+          const interpreter = new Interpreter({
+            globals: {
+              createValues: () => Array.from({ length: 100 }, (_, index) => index),
+            },
+          });
+          expect(() => {
+            interpreter.evaluate(`createValues();`, { maxMemory: 1000 });
+          }).toThrow("Maximum memory limit exceeded");
+        });
+
         test("should reset memory tracking between evaluations", () => {
           // First interpreter uses some memory
           const interpreter1 = new Interpreter();

--- a/test/execution-control.test.ts
+++ b/test/execution-control.test.ts
@@ -339,6 +339,22 @@ describe("Execution Control", () => {
           }).toThrow("Maximum memory limit exceeded");
         });
 
+        test("should not double count split without a separator", () => {
+          const interpreter = new Interpreter();
+          const result = interpreter.evaluate(
+            `
+              const base = "hello world";
+              for (let i = 0; i < 10; i++) {
+                base.split();
+              }
+              base.length;
+            `,
+            { maxMemory: 200, maxLoopIterations: 100000 },
+          );
+
+          expect(result).toBe(11);
+        });
+
         test("should throw when materialized host returns exceed memory limit", () => {
           const interpreter = new Interpreter({
             globals: {
@@ -348,6 +364,42 @@ describe("Execution Control", () => {
           expect(() => {
             interpreter.evaluate(`createValues();`, { maxMemory: 1000 });
           }).toThrow("Maximum memory limit exceeded");
+        });
+
+        test("should rethrow sandbox memory errors from host callbacks without host wrapping", () => {
+          const interpreter = new Interpreter({
+            globals: {
+              runCallback: (callback: () => void) => callback(),
+            },
+          });
+
+          expect(() => {
+            interpreter.evaluate(
+              `
+                runCallback(() => {
+                  const base = "hello";
+                  for (let i = 0; i < 100; i++) {
+                    base.repeat(10);
+                  }
+                });
+              `,
+              { maxMemory: 1000, maxLoopIterations: 100000 },
+            );
+          }).toThrow("Maximum memory limit exceeded");
+
+          expect(() => {
+            interpreter.evaluate(
+              `
+                runCallback(() => {
+                  const base = "hello";
+                  for (let i = 0; i < 100; i++) {
+                    base.repeat(10);
+                  }
+                });
+              `,
+              { maxMemory: 1000, maxLoopIterations: 100000 },
+            );
+          }).not.toThrow("Host function 'runCallback' threw error");
         });
 
         test("should reset memory tracking between evaluations", () => {


### PR DESCRIPTION
## Summary

Closes #237.

This PR expands the interpreter's best-effort memory accounting so `maxMemory` catches allocations that happen outside literal/template evaluation.

## Changes

- Added centralized allocation helpers for arrays, objects, and strings using the existing deterministic estimates.
- Applied accounting to common allocating array built-ins such as `map`, `filter`, `slice`, `concat`, `flat`, `flatMap`, `splice`, and `join` string output.
- Applied accounting to common allocating string built-ins such as `repeat`, `replace`, `padStart`, `padEnd`, `slice`, case conversion, trimming, and `split` output.
- Accounted for destructuring rest containers, function `arguments`/rest parameter arrays, and materialized host-return arrays/plain objects.
- Preserved interpreter/resource-limit errors thrown inside host wrappers so `maxMemory` failures surface directly instead of being converted to generic host errors.
- Documented the expanded best-effort allocation strategy and added a patch changeset.

## Root Cause

`trackMemory()` was only used in literal/template evaluator paths, so helper methods and host-return materialization could create new arrays, objects, or strings without increasing the current memory usage estimate.

## Validation

- `bun fmt`
- `bun lint:fix` (completed with existing `no-unreachable` warnings in `test/security.test.ts`)
- `bun test`
- `bun typecheck`
- `bun lint` (completed with existing `no-unreachable` warnings in `test/security.test.ts`)
- `bun fmt:check`