### PR TITLE
[codex] Fix large array spread host argument limits

### DIFF
--- a/.changeset/warm-maps-spread.md
+++ b/.changeset/warm-maps-spread.md
@@ -1,0 +1,5 @@
+---
+"nookjs": patch
+---
+
+Avoid host argument limits when materializing large array literal spreads.

--- a/src/interpreter.ts
+++ b/src/interpreter.ts
@@ -10184,7 +10184,7 @@ export class Interpreter {
 
         const spreadValue = this.evaluateNode((element as ESTree.SpreadElement).argument);
         const spreadArray = this.validateArraySpread(spreadValue);
-        elements.push(...spreadArray);
+        this.appendSpreadArgs(elements, spreadArray);
       } else {
         elements.push(this.evaluateNode(element));
       }
@@ -12325,7 +12325,7 @@ export class Interpreter {
           (element as ESTree.SpreadElement).argument,
         );
         const spreadArray = this.validateArraySpread(spreadValue);
-        elements.push(...spreadArray);
+        this.appendSpreadArgs(elements, spreadArray);
       } else {
         let val = await this.evaluateNodeAsync(element);
         // Unwrap RawValue (used to prevent Promise auto-awaiting from call/new expressions)

--- a/test/arrays.test.ts
+++ b/test/arrays.test.ts
@@ -62,6 +62,20 @@ describe("Arrays", () => {
             `);
         expect(result).toEqual([3, false, undefined]);
       });
+
+      test("large array spread does not exceed host call argument limits", () => {
+        const arr = Array.from({ length: 200_000 }, (_, index) => index);
+        const largeSpreadInterpreter = new Interpreter({ globals: { arr } });
+
+        expect(largeSpreadInterpreter.evaluate("[...arr].length")).toBe(arr.length);
+      });
+
+      test("large array spread in evaluateAsync does not exceed host call argument limits", async () => {
+        const arr = Array.from({ length: 200_000 }, (_, index) => index);
+        const largeSpreadInterpreter = new Interpreter({ globals: { arr } });
+
+        expect(await largeSpreadInterpreter.evaluateAsync("[...arr].length")).toBe(arr.length);
+      });
     });
 
     describe("Array indexing", () => {


### PR DESCRIPTION
## Summary

Fixes #238.

Array literal spread materialization used `elements.push(...spreadArray)` in both sync and async evaluation paths. For large iterables, that expands the spread values as host call arguments and can exceed the JavaScript runtime's call argument limit before the interpreter can return a result or apply its own resource limits.

This PR reuses the existing iterative spread append helper that call argument evaluation already uses, so array literal spreads append values one by one instead of invoking variadic `push`.

## Changes

- Replaced sync and async array literal `push(...spreadArray)` calls with iterative appends.
- Added sync and async regression tests for a 200,000-element host array spread.
- Added a patch changeset for the fix.

## Validation

- `bun fmt`
- `bun lint:fix`
- `bun lint` exits 0, with existing unrelated unreachable-code warnings in `test/security.test.ts`
- `bun test`
- `bun typecheck`
- `bun fmt:check`